### PR TITLE
nose

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,8 @@ setup(
     author_email='erikrose@grinchcentral.com',
     license='MIT',
     packages=find_packages(exclude=['ez_setup']),
-    tests_require=['Nose'],
+    tests_require=['nose'],
+    test_suite='nose.collector',
     url='https://github.com/erikrose/parsimonious',
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
Hi and thanks for the great talk!
I just added in the setup.py the entry point for tests, which then uses nose by default.
Strangely though even if all the tests pass perfectly running "python setup.py test" gives in the end this traceback below.

I think, however, that it's my machine problem, maybe the multiprocessing plugin..

OK
Error in atexit._run_exitfuncs:
Traceback (most recent call last):
  File "/usr/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(_targs, *_kargs)
  File "/usr/lib/python2.7/multiprocessing/util.py", line 284, in _exit_function
    info('process shutting down')
TypeError: 'NoneType' object is not callable
Error in sys.exitfunc:
Traceback (most recent call last):
  File "/usr/lib/python2.7/atexit.py", line 24, in _run_exitfuncs
    func(_targs, *_kargs)
  File "/usr/lib/python2.7/multiprocessing/util.py", line 284, in _exit_function
    info('process shutting down')
TypeError: 'NoneType' object is not callable
