### PR TITLE
Use modern `except` syntax

### DIFF
--- a/parsimonious/nodes.py
+++ b/parsimonious/nodes.py
@@ -163,7 +163,7 @@ class NodeVisitor(object):
         except VisitationError:
             # Don't catch and re-wrap already-wrapped exceptions.
             raise
-        except Exception, e:
+        except Exception as e:
             # Catch any exception, and tack on a parse tree so it's easier to
             # see where it went wrong.
             exc_class, exc, tb = sys.exc_info()


### PR DESCRIPTION
The `except Exception as e` form is preferred over the older `except Exception, e` form, as it works in both Python 2 and 3.
