### PR TITLE
Use modern `str.format()` instead of old-style `%` string formatting

### DIFF
--- a/parsimonious/exceptions.py
+++ b/parsimonious/exceptions.py
@@ -23,12 +23,11 @@ class VisitationError(Exception):
         """
         self.original_class = exc_class
         super(VisitationError, self).__init__(
-            '%s: %s\n\n'
+            '{0}: {1}\n\n'
             'Parse tree:\n'
-            '%s' %
-            (exc_class.__name__,
-             exc,
-             node.prettily(error=node)))
+            '{2}'.format(exc_class.__name__,
+                         exc,
+                         node.prettily(error=node)))
 
 
 class UndefinedLabel(VisitationError):
@@ -42,6 +41,6 @@ class UndefinedLabel(VisitationError):
         self.label = label
 
     def __unicode__(self):
-        return u'The label "%s" was never defined.' % self.label
+        return u'The label "{0}" was never defined.'.format(self.label)
 
     __str__ = __unicode__

--- a/parsimonious/expressions.py
+++ b/parsimonious/expressions.py
@@ -79,7 +79,7 @@ class Expression(StrAndRepr):
         return uncached
 
     def __unicode__(self):
-        return u'<%s %s at 0x%s>' % (
+        return u'<{0} {1} at 0x{2}>'.format(
             self.__class__.__name__,
             self.as_rule(),
             id(self))
@@ -90,7 +90,7 @@ class Expression(StrAndRepr):
         Return unicode. If I have no ``name``, omit the left-hand side.
 
         """
-        return ((u'%s = %s' % (self.name, self._as_rhs())) if self.name else
+        return ((u'{0} = {1}'.format(self.name, self._as_rhs())) if self.name else
                 self._as_rhs())
 
     def _unicode_members(self):
@@ -126,7 +126,7 @@ class Literal(Expression):
 
     def _as_rhs(self):
         # TODO: Get backslash escaping right.
-        return '"%s"' % self.literal
+        return '"{0}"'.format(self.literal)
 
 
 class Regex(Expression):
@@ -164,7 +164,7 @@ class Regex(Expression):
 
     def _as_rhs(self):
         # TODO: Get backslash escaping right.
-        return '~"%s"%s' % (self.re.pattern,
+        return '~"{0}"{1}'.format(self.re.pattern,
                             self._regex_flags_from_bits(self.re.flags))
 
 
@@ -237,7 +237,7 @@ class Lookahead(_Compound):
             return Node(self.name, text, pos, pos)
 
     def _as_rhs(self):
-        return u'&%s' % self._unicode_members()[0]
+        return u'&{0}'.format(self._unicode_members()[0])
 
 
 class Not(_Compound):
@@ -256,7 +256,7 @@ class Not(_Compound):
     def _as_rhs(self):
         # TODO: Make sure this parenthesizes the member properly if it's an OR
         # or AND.
-        return u'!%s' % self._unicode_members()[0]
+        return u'!{0}'.format(self._unicode_members()[0])
 
 
 # Quantifiers. None of these is strictly necessary, but they're darn handy.
@@ -274,7 +274,7 @@ class Optional(_Compound):
                 Node(self.name, text, pos, node.end, children=[node]))
 
     def _as_rhs(self):
-        return u'%s?' % self._unicode_members()[0]
+        return u'{0}?'.format(self._unicode_members()[0])
 
 
 # TODO: Merge with OneOrMore.
@@ -292,7 +292,7 @@ class ZeroOrMore(_Compound):
             new_pos += node.end - node.start
 
     def _as_rhs(self):
-        return u'%s*' % self._unicode_members()[0]
+        return u'{0}*'.format(self._unicode_members()[0])
 
 
 class OneOrMore(_Compound):
@@ -327,4 +327,4 @@ class OneOrMore(_Compound):
             return Node(self.name, text, pos, new_pos, children)
 
     def _as_rhs(self):
-        return u'%s+' % self._unicode_members()[0]
+        return u'{0}+'.format(self._unicode_members()[0])

--- a/parsimonious/grammar.py
+++ b/parsimonious/grammar.py
@@ -106,7 +106,7 @@ class Grammar(StrAndRepr, dict):
 
     def __repr__(self):
         """Return an expression that will reconstitute the grammar."""
-        return "Grammar('%s')" % str(self).encode('string_escape')
+        return "Grammar('{0}')".format( str(self).encode('string_escape') )
 
 
 class BootstrappingGrammar(Grammar):

--- a/parsimonious/nodes.py
+++ b/parsimonious/nodes.py
@@ -70,9 +70,9 @@ class Node(object):
         # them all. Whoops.
         def indent(text):
             return '\n'.join(('    ' + line) for line in text.splitlines())
-        ret = [u'<%s%s matching "%s">%s' % (
+        ret = [u'<{0}{1} matching "{2}">{3}'.format(
             self.__class__.__name__,
-            (' called "%s"' % self.expr_name) if self.expr_name else '',
+            (' called "{0}"'.format(self.expr_name)) if self.expr_name else '',
             self.text,
             '  <-- *** We were here. ***' if error is self else '')]
         for n in self:
@@ -103,15 +103,15 @@ class Node(object):
         me."""
         # repr() of unicode flattens everything out to ASCII, so we don't need
         # to explicitly encode things afterward.
-        ret = ["s = %r" % self.full_text] if top_level else []
-        ret.append("%s(%r, s, %s, %s%s)" % (
+        ret = ["s = {0!r}".format(self.full_text)] if top_level else []
+        ret.append("{0}({1!r}, s, {2}, {3}{4})".format(
             self.__class__.__name__,
             self.expr_name,
             self.start,
             self.end,
-            (', children=[%s]' %
-             ', '.join([c.__repr__(top_level=False) for c in self.children]))
-            if self.children else ''))
+            ('' if not self.children else ', children=[{0}]'.format(
+                ', '.join([c.__repr__(top_level=False) for c in self.children]))
+            )))
         return '\n'.join(ret)
 
 

--- a/parsimonious/tests/test_benchmarks.py
+++ b/parsimonious/tests/test_benchmarks.py
@@ -15,7 +15,7 @@ def test_lists_vs_dicts():
     dict_time = timeit('item = d[9000]', 'd = dict((x, 0) for x in xrange(10000))')
 
     # Dicts take about 1.6x as long as lists in Python 2.6 and 2.7.
-    ok_(list_time < dict_time, '%s < %s' % (list_time, dict_time))
+    ok_(list_time < dict_time, '{0} < {1}'.format(list_time, dict_time))
 
 
 def test_call_vs_inline():
@@ -27,7 +27,7 @@ def test_call_vs_inline():
 
     # Calling a function is pretty fast; it takes just 1.2x as long as the
     # global var access and addition in l[0] += 1.
-    ok_(no_call < call, '%s (no call) < %s (call)' % (no_call, call))
+    ok_(no_call < call, '{0} (no call) < {1} (call)'.format(no_call, call))
 
 
 def test_startswith_vs_regex():
@@ -42,4 +42,4 @@ def test_startswith_vs_regex():
 
     # Regexes take 2.24x as long as simple string matching.
     ok_(startswith_time < re_time,
-        '%s (startswith) < %s (re)' % (startswith_time, re_time))
+        '{0} (startswith) < {1} (re)'.format(startswith_time, re_time))


### PR DESCRIPTION
**Source:**
http://docs.python.org/2.7/library/stdtypes.html?highlight=.format#str.format

```
str.format() is the new standard in Python 3, and should be preferred to the 
`%` formatting described in String Formatting Operations in new code.

New in version 2.6.
```
