### PR TITLE
Solve error in Grammar.__repr__ in Python3

### DIFF
--- a/parsimonious/grammar.py
+++ b/parsimonious/grammar.py
@@ -101,7 +101,7 @@ class Grammar(StrAndRepr, dict):
 
     def __repr__(self):
         """Return an expression that will reconstitute the grammar."""
-        return "Grammar('%s')" % str(self).encode('string_escape')
+        return "Grammar('%s')" % str(self).encode('unicode_escape')
 
 
 class BootstrappingGrammar(Grammar):


### PR DESCRIPTION
This is an excerpt from the Python3-IDLE on Ubuntu 12.04 LTS
>>> from parsimonious.grammar import Grammar
>>> grammar = Grammar(
"""
bold_text  = bold_open text bold_close
text       = ~"[A-Z 0-9]*"i
bold_open  = "(("
bold_close = "))"
""")
>>> grammar
Traceback (most recent call last):
  File "<pyshell#2>", line 1, in <module>
    grammar
  File "/usr/local/lib/python3.2/dist-packages/parsimonious-0.5-py3.2.egg/parsimonious/grammar.py", line 104, in __repr__
    return "Grammar('%s')" % str(self).encode('string_escape')
LookupError: unknown encoding: string_escape
>>> 

Replaced string_escape by unicode_escape.
Works also with Python2.