### PR TITLE
Added the ability of parsimonious to parse lists of tokens.

### DIFF
--- a/parsimonious/nodes.py
+++ b/parsimonious/nodes.py
@@ -33,7 +33,7 @@ class Node(StrAndRepr):
     __slots__ = ['expr_name',  # The name of the expression that generated me
                  'full_text',  # The full text fed to the parser
                  'start', # The position in the text where that expr started matching
-                 'end',   # The position after start where the expr first didn't
+                 'end',   # The position after starft where the expr first didn't
                           # match. [start:end] follow Python slice conventions.
                  'children']  # List of child parse tree nodes
 

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -5,6 +5,7 @@ from nose import SkipTest
 from nose.tools import eq_, assert_raises, ok_
 
 from parsimonious.exceptions import UndefinedLabel, ParseError
+from parsimonious.expressions import Token
 from parsimonious.nodes import Node
 from parsimonious.grammar import rule_grammar, RuleVisitor, Grammar
 
@@ -296,3 +297,20 @@ class GrammarTests(TestCase):
 
     def test_single_quoted_literals(self):
         Grammar("""foo = 'a' '"'""").parse('a"')
+
+
+class TokenListTests(TestCase):
+    def test_token_list_grammar(self):
+        """Token literals should work."""
+        grammar = Grammar("""
+            foo = %TOKEN1% %TOKEN2%
+            """)
+        ok_(grammar.parse([Token("TOKEN1"), Token("TOKEN2")]) is not None)
+
+    def test_token_list_grammar_false(self):
+        """Token literals should work."""
+        grammar = Grammar("""
+            foo = %TOKEN1% %TOKEN2%
+            """)
+        assert_raises(ParseError, grammar.parse, [Token("TOKEN"), Token("TOKEN2")])
+


### PR DESCRIPTION
Not sure you wanted this in parsimonious, but I needed it. I implemented a language with Python-like indentation; this indentation is usually implemented in the lexer. I am using PLY.

However, LALR(1) grammars suck, so I wanted something with more lookahead. But all PEG grammars insisted on doing the lexing themselves (bah!).

But parsimonious was so simply written that it was trivial to change to do what I needed.

Now if you call grammar.parse on a list, it will assume that the list is a list of "tokens": a token is an instance with a member called "type".

To match a token of a given type, you may use the syntax %TOKEN_TYPE% in the grammar.

Example usage:

grammar = Grammar("""foo = %TOKEN1% %TOKEN2%""")
assert(grammar.parse([Token("TOKEN1"), Token("TOKEN2")]) is not None)


I've already tested it on my project, it works just fine :-)