### PR TITLE
Type check when comparing nodes

### DIFF
--- a/parsimonious/nodes.py
+++ b/parsimonious/nodes.py
@@ -90,6 +90,9 @@ class Node(StrAndRepr):
 
     def __eq__(self, other):
         """Support by-value deep comparison with other nodes for testing."""
+        if not isinstance(other, Node):
+            return NotImplemented
+
         return (other is not None and
                 self.expr_name == other.expr_name and
                 self.full_text == other.full_text and

--- a/parsimonious/nodes.py
+++ b/parsimonious/nodes.py
@@ -93,8 +93,7 @@ class Node(StrAndRepr):
         if not isinstance(other, Node):
             return NotImplemented
 
-        return (other is not None and
-                self.expr_name == other.expr_name and
+        return (self.expr_name == other.expr_name and
                 self.full_text == other.full_text and
                 self.start == other.start and
                 self.end == other.end and

--- a/parsimonious/tests/test_nodes.py
+++ b/parsimonious/tests/test_nodes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from nose import SkipTest
-from nose.tools import eq_, assert_raises
+from nose.tools import eq_, ok_, assert_raises
 
 from parsimonious import Grammar, NodeVisitor, VisitationError, rule
 from parsimonious.nodes import Node
@@ -146,4 +146,5 @@ def test_unwrapped_exceptions():
 
 def test_node_inequality():
     node = Node('text', 'o hai', 0, 5)
-    assert node != 5
+    ok_(node != 5)
+    ok_(node != None)

--- a/parsimonious/tests/test_nodes.py
+++ b/parsimonious/tests/test_nodes.py
@@ -142,3 +142,8 @@ def test_unwrapped_exceptions():
             raise PrimalScream('This should percolate up!')
 
     assert_raises(PrimalScream, Screamer().parse, 'howdy')
+
+
+def test_node_inequality():
+    node = Node('text', 'o hai', 0, 5)
+    assert node != 5


### PR DESCRIPTION
This should close #95 by making the `Node` give up comparisons with things that are not of its class.

I went with returning `NotImplemented` as that gives `other` a chance to do the comparison.

I thought about using
```python
if not isinstance(other, type(self)):
    ...
```
But I don't really know what is the preferred style, so I just went with the simpler.