### PR TITLE
Ordered rules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
   - "3.3"
   - "3.4"
   - "3.5"
+  - "3.6"
 install:
   - pip install tox tox-travis
 script:

--- a/parsimonious/grammar.py
+++ b/parsimonious/grammar.py
@@ -66,8 +66,8 @@ class Grammar(OrderedDict):
             k: (expression(v, k, self) if isfunction(v) or ismethod(v) else v)
             for k, v in iteritems(more_rules)}
 
-        expressions, first = self._expressions_from_rules(rules, decorated_custom_rules)
-        super(Grammar, self).__init__(expressions.items())
+        exprs, first = self._expressions_from_rules(rules, decorated_custom_rules)
+        super(Grammar, self).__init__(exprs.items())
         self.default_rule = first  # may be None
 
     def default(self, rule_name):
@@ -85,9 +85,8 @@ class Grammar(OrderedDict):
 
         """
         new = Grammar.__new__(Grammar)
-        super(Grammar, new).__init__(self.items())
+        super(Grammar, new).__init__(iteritems(self))
         new.default_rule = self.default_rule
-        new.update(self.items())
         return new
 
     def _expressions_from_rules(self, rules, custom_rules):

--- a/parsimonious/grammar.py
+++ b/parsimonious/grammar.py
@@ -94,8 +94,9 @@ class Grammar(Mapping):
         no Expressions.
 
         """
-        new = Grammar(**self._expressions)
+        new = Grammar.__new__(Grammar)
         new.default_rule = self.default_rule
+        new._expressions = self._expressions.copy()
         return new
 
     def _expressions_from_rules(self, rules, custom_rules):

--- a/parsimonious/grammar.py
+++ b/parsimonious/grammar.py
@@ -6,6 +6,7 @@ by hand.
 
 """
 from collections import Mapping
+from collections import OrderedDict
 from inspect import isfunction, ismethod
 
 from six import (text_type, iterkeys, itervalues, iteritems,
@@ -62,10 +63,10 @@ class Grammar(Mapping):
             ``rules`` in case of naming conflicts.
 
         """
-        decorated_custom_rules = dict(
-            (k, expression(v, k, self) if isfunction(v) or
-                                          ismethod(v) else
-                v) for k, v in iteritems(more_rules))
+
+        decorated_custom_rules = {
+            k: (expression(v, k, self) if isfunction(v) or ismethod(v) else v)
+            for k, v in iteritems(more_rules)}
 
         self._expressions, first = self._expressions_from_rules(rules, decorated_custom_rules)
         self.default_rule = first  # may be None
@@ -448,7 +449,7 @@ class RuleVisitor(NodeVisitor):
         # override earlier ones. This lets us define rules multiple times and
         # have the last declaration win, so you can extend grammars by
         # concatenation.
-        rule_map = dict((expr.name, expr) for expr in rules)
+        rule_map = OrderedDict((expr.name, expr) for expr in rules)
 
         # And custom rules override string-based rules. This is the least
         # surprising choice when you compare the dict constructor:
@@ -457,8 +458,8 @@ class RuleVisitor(NodeVisitor):
 
         # Resolve references. This tolerates forward references.
         done = set()
-        rule_map = dict((expr.name, self._resolve_refs(rule_map, expr, done))
-                        for expr in itervalues(rule_map))
+        rule_map = OrderedDict((expr.name, self._resolve_refs(rule_map, expr, done))
+                               for expr in itervalues(rule_map))
 
         # isinstance() is a temporary hack around the fact that * rules don't
         # always get transformed into lists by NodeVisitor. We should fix that;

--- a/parsimonious/grammar.py
+++ b/parsimonious/grammar.py
@@ -20,7 +20,7 @@ from parsimonious.nodes import NodeVisitor
 from parsimonious.utils import evaluate_string
 
 @python_2_unicode_compatible
-class Grammar(Mapping):
+class Grammar(OrderedDict):
     """A collection of rules that describe a language
 
     You can start parsing from the default rule by calling ``parse()``
@@ -68,17 +68,9 @@ class Grammar(Mapping):
             k: (expression(v, k, self) if isfunction(v) or ismethod(v) else v)
             for k, v in iteritems(more_rules)}
 
-        self._expressions, first = self._expressions_from_rules(rules, decorated_custom_rules)
+        expressions, first = self._expressions_from_rules(rules, decorated_custom_rules)
+        super(Grammar, self).__init__(expressions.items())
         self.default_rule = first  # may be None
-
-    def __getitem__(self, rule_name):
-        return self._expressions[rule_name]
-
-    def __iter__(self):
-        return iterkeys(self._expressions)
-
-    def __len__(self):
-        return len(self._expressions)
 
     def default(self, rule_name):
         """Return a new Grammar whose :term:`default rule` is ``rule_name``."""
@@ -95,8 +87,9 @@ class Grammar(Mapping):
 
         """
         new = Grammar.__new__(Grammar)
+        super(Grammar, new).__init__(self.items())
         new.default_rule = self.default_rule
-        new._expressions = self._expressions.copy()
+        new.update(self.items())
         return new
 
     def _expressions_from_rules(self, rules, custom_rules):

--- a/parsimonious/grammar.py
+++ b/parsimonious/grammar.py
@@ -16,10 +16,10 @@ from parsimonious.expressions import (Literal, Regex, Sequence, OneOf,
     Lookahead, Optional, ZeroOrMore, OneOrMore, Not, TokenMatcher,
     expression)
 from parsimonious.nodes import NodeVisitor
-from parsimonious.utils import StrAndRepr, evaluate_string
+from parsimonious.utils import evaluate_string
 
 @python_2_unicode_compatible
-class Grammar(StrAndRepr, Mapping):
+class Grammar(Mapping):
     """A collection of rules that describe a language
 
     You can start parsing from the default rule by calling ``parse()``

--- a/parsimonious/grammar.py
+++ b/parsimonious/grammar.py
@@ -5,12 +5,10 @@ optimizations that would be tedious to do when constructing an expression tree
 by hand.
 
 """
-from collections import Mapping
 from collections import OrderedDict
 from inspect import isfunction, ismethod
 
-from six import (text_type, iterkeys, itervalues, iteritems,
-    python_2_unicode_compatible, PY2)
+from six import (text_type, itervalues, iteritems, python_2_unicode_compatible, PY2)
 
 from parsimonious.exceptions import BadGrammar, UndefinedLabel
 from parsimonious.expressions import (Literal, Regex, Sequence, OneOf,

--- a/parsimonious/nodes.py
+++ b/parsimonious/nodes.py
@@ -13,11 +13,10 @@ from six import reraise, python_2_unicode_compatible, with_metaclass, \
     iteritems
 
 from parsimonious.exceptions import VisitationError, UndefinedLabel
-from parsimonious.utils import StrAndRepr
 
 
 @python_2_unicode_compatible
-class Node(StrAndRepr):
+class Node(object):
     """A parse tree node
 
     Consider these immutable once constructed. As a side effect of a

--- a/parsimonious/tests/test_benchmarks.py
+++ b/parsimonious/tests/test_benchmarks.py
@@ -13,7 +13,7 @@ timeit = partial(timeit, number=500000)
 def test_lists_vs_dicts():
     """See what's faster at int key lookup: dicts or lists."""
     list_time = timeit('item = l[9000]', 'l = [0] * 10000')
-    dict_time = timeit('item = d[9000]', 'd = dict((x, 0) for x in range(10000))')
+    dict_time = timeit('item = d[9000]', 'd = {x: 0 for x in range(10000)}')
 
     # Dicts take about 1.6x as long as lists in Python 2.6 and 2.7.
     ok_(list_time < dict_time, '%s < %s' % (list_time, dict_time))

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -410,7 +410,7 @@ class GrammarTests(TestCase):
             list(grammar.keys()),
             ['r%s' % i for i in range(100)])
 
-    def test_rule_ordering_is_on_shallow_copies(self):
+    def test_rule_ordering_is_preserved_on_shallow_copies(self):
         grammar = Grammar('\n'.join('r%s = "something"' % i for i in range(100)))._copy()
         self.assertEqual(
             list(grammar.keys()),

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -404,6 +404,12 @@ class GrammarTests(TestCase):
     def test_repr(self):
         self.assertTrue(repr(Grammar(r'foo = "a"')))
 
+    def test_rule_ordering_is_preserved(self):
+        grammar = Grammar('\n'.join('r%s = "something"' % i for i in range(100)))
+        self.assertEqual(
+            list(grammar.keys()),
+            ['r%s' % i for i in range(100)])
+
 
 class TokenGrammarTests(TestCase):
     """Tests for the TokenGrammar class and associated machinery"""

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -1,6 +1,9 @@
+# coding=utf-8
+
 from sys import version_info
 from unittest import TestCase
 
+import sys
 from nose import SkipTest
 from nose.tools import eq_, assert_raises, ok_
 from six import text_type
@@ -440,3 +443,11 @@ class TokenGrammarTests(TestCase):
         assert_raises(ParseError,
                       grammar.parse,
                       [Token('tokenBOO'), Token('token2')])
+
+    def test_token_repr(self):
+        t = Token(u'💣')
+        self.assertTrue(isinstance(t.__repr__(), str))
+        if sys.version_info < (3, 0):
+            self.assertEqual(u'<Token "💣">'.encode('utf-8'), t.__repr__())
+        else:
+            self.assertEqual(u'<Token "💣">', t.__repr__())

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -410,6 +410,12 @@ class GrammarTests(TestCase):
             list(grammar.keys()),
             ['r%s' % i for i in range(100)])
 
+    def test_rule_ordering_is_on_shallow_copies(self):
+        grammar = Grammar('\n'.join('r%s = "something"' % i for i in range(100)))._copy()
+        self.assertEqual(
+            list(grammar.keys()),
+            ['r%s' % i for i in range(100)])
+
 
 class TokenGrammarTests(TestCase):
     """Tests for the TokenGrammar class and associated machinery"""

--- a/parsimonious/utils.py
+++ b/parsimonious/utils.py
@@ -1,22 +1,15 @@
 """General tools which don't depend on other parts of Parsimonious"""
 
 import ast
-from sys import version_info
 
 from six import python_2_unicode_compatible
 
 
 class StrAndRepr(object):
-    """Mix-in to add a ``__str__`` and ``__repr__`` which return the
-    UTF-8-encoded value of ``__unicode__``"""
+    """Mix-in to which gives the class the same __repr__ and __str__."""
 
-    if version_info >= (3,):
-        # Don't return the "bytes" type from Python 3's __str__:
-        def __repr__(self):
-            return self.__str__()
-    else:
-        def __repr__(self):
-            return self.__str__().encode('utf-8')
+    def __repr__(self):
+        return self.__str__()
 
 
 def evaluate_string(string):

--- a/parsimonious/utils.py
+++ b/parsimonious/utils.py
@@ -6,7 +6,7 @@ from six import python_2_unicode_compatible
 
 
 class StrAndRepr(object):
-    """Mix-in to which gives the class the same __repr__ and __str__."""
+    """Mix-in which gives the class the same __repr__ and __str__."""
 
     def __repr__(self):
         return self.__str__()

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,14 @@
 [tox]
-envlist = py26, py27, py33, py34, py35
+envlist = py27, py33, py34, py35, py36
 
 [tox:travis]
-2.6 = py26
 2.7 = py27
 3.3 = py33
 3.4 = py34
 3.5 = py35
+3.6 = py36
 
 [testenv]
 usedevelop = True
 commands = nosetests parsimonious
 deps = nose
-# So Python 3 doesn't pick up incompatible, un-2to3'd source from the cwd:
-changedir = .tox


### PR DESCRIPTION
@erikrose This PR makes `Grammar` respect the ordering of rules in the grammar definition by having it inherit from `OrderedDict`. This necessitated dropping python 2.6 support, though as a bonus, I added python 3.6 to the build matrix.

I also fixed a bug with `StrAndRepr`, and updated the code to use dict comprehensions where possible.

## Testing

I added two tests:
- One to verify that rule ordering is preserved when a grammar is parsed. This failed on Python <3.6.
- One to verify that rule ordering is preserved when a shallow copy of the grammar is made. This failed on Python <3.6. 

The full test suite now passes on the supported versions of python.