### PR TITLE
Improve error messages for unnamed nodes

### DIFF
--- a/parsimonious/expressions.py
+++ b/parsimonious/expressions.py
@@ -217,17 +217,18 @@ class Literal(Expression):
     Use these if you can; they're the fastest.
 
     """
-    __slots__ = ['literal']
+    __slots__ = ['literal', 'identity_tuple']
 
     def __init__(self, literal, name=''):
         super(Literal, self).__init__(name)
         self.literal = literal
+        self.identity_tuple = (name, literal)
 
     def __hash__(self):
-        return hash((self.literal, self.name))
+        return hash(self.identity_tuple)
 
     def __eq__(self, other):
-        return isinstance(other, Literal) and self.literal == other.literal
+        return isinstance(other, Literal) and self.identity_tuple == other.identity_tuple
 
     def __ne__(self, other):
         return not (self == other)
@@ -259,7 +260,7 @@ class Regex(Expression):
     they're fast.
 
     """
-    __slots__ = ['re']
+    __slots__ = ['re', 'identity_tuple']
 
     def __init__(self, pattern, name='', ignore_case=False, locale=False,
                  multiline=False, dot_all=False, unicode=False, verbose=False):
@@ -270,12 +271,13 @@ class Regex(Expression):
                                       (dot_all and re.S) |
                                       (unicode and re.U) |
                                       (verbose and re.X))
+        self.identity_tuple = (self.name, self.re)
 
     def __hash__(self):
-        return hash((self.name, self.re))
+        return hash(self.identity_tuple)
 
     def __eq__(self, other):
-        return isinstance(other, Regex) and (self.name, self.re) == (other.name, other.re)
+        return isinstance(other, Regex) and self.identity_tuple == other.identity_tuple
 
     def __ne__(self, other):
         return not (self == other)
@@ -308,7 +310,7 @@ class Compound(Expression):
     def __init__(self, *members, **kwargs):
         """``members`` is a sequence of expressions."""
         super(Compound, self).__init__(kwargs.get('name', ''))
-        self.members = tuple(members)
+        self.members = members
 
     def __hash__(self):
         # Note we leave members out of the hash computation, since compounds can get added to

--- a/parsimonious/grammar.py
+++ b/parsimonious/grammar.py
@@ -420,8 +420,8 @@ class RuleVisitor(NodeVisitor):
                 # of `expr.members` can refer back to `expr`, but it can't go
                 # any farther.
                 done.add(expr)
-                expr.members = tuple([self._resolve_refs(rule_map, member, done)
-                                      for member in expr.members])
+                expr.members = tuple(self._resolve_refs(rule_map, member, done)
+                                     for member in expr.members)
             return expr
 
     def visit_rules(self, node, rules_list):

--- a/parsimonious/grammar.py
+++ b/parsimonious/grammar.py
@@ -420,8 +420,8 @@ class RuleVisitor(NodeVisitor):
                 # of `expr.members` can refer back to `expr`, but it can't go
                 # any farther.
                 done.add(expr)
-                expr.members = [self._resolve_refs(rule_map, member, done)
-                                for member in expr.members]
+                expr.members = tuple([self._resolve_refs(rule_map, member, done)
+                                      for member in expr.members])
             return expr
 
     def visit_rules(self, node, rules_list):

--- a/parsimonious/nodes.py
+++ b/parsimonious/nodes.py
@@ -34,19 +34,24 @@ class Node(object):
     """
     # I tried making this subclass list, but it got ugly. I had to construct
     # invalid ones and patch them up later, and there were other problems.
-    __slots__ = ['expr_name',  # The name of the expression that generated me
+    __slots__ = ['expr',  # The expression that generated me
                  'full_text',  # The full text fed to the parser
                  'start', # The position in the text where that expr started matching
                  'end',   # The position after start where the expr first didn't
                           # match. [start:end] follow Python slice conventions.
                  'children']  # List of child parse tree nodes
 
-    def __init__(self, expr_name, full_text, start, end, children=None):
-        self.expr_name = expr_name
+    def __init__(self, expr, full_text, start, end, children=None):
+        self.expr = expr
         self.full_text = full_text
         self.start = start
         self.end = end
         self.children = children or []
+
+    @property
+    def expr_name(self):
+        # backwards compatibility
+        return self.expr.name
 
     def __iter__(self):
         """Support looping over my children and doing tuple unpacks on me.
@@ -92,7 +97,7 @@ class Node(object):
         if not isinstance(other, Node):
             return NotImplemented
 
-        return (self.expr_name == other.expr_name and
+        return (self.expr == other.expr and
                 self.full_text == other.full_text and
                 self.start == other.start and
                 self.end == other.end and
@@ -109,7 +114,7 @@ class Node(object):
         ret = ["s = %r" % self.full_text] if top_level else []
         ret.append("%s(%r, s, %s, %s%s)" % (
             self.__class__.__name__,
-            self.expr_name,
+            self.expr,
             self.start,
             self.end,
             (', children=[%s]' %

--- a/parsimonious/nodes.py
+++ b/parsimonious/nodes.py
@@ -238,7 +238,7 @@ class NodeVisitor(with_metaclass(RuleDecoratorMeta, object)):
         for now.
 
         """
-        raise NotImplementedError('No visitor method was defined for %s.' %
+        raise NotImplementedError('No visitor method was defined for this expression: %s' %
                                   node.expr.as_rule())
 
     # Convenience methods:

--- a/parsimonious/nodes.py
+++ b/parsimonious/nodes.py
@@ -238,8 +238,8 @@ class NodeVisitor(with_metaclass(RuleDecoratorMeta, object)):
         for now.
 
         """
-        raise NotImplementedError('No visitor method was defined for "%s".' %
-                                  node.expr_name)
+        raise NotImplementedError('No visitor method was defined for %s.' %
+                                  node.expr.as_rule())
 
     # Convenience methods:
 

--- a/parsimonious/tests/test_expressions.py
+++ b/parsimonious/tests/test_expressions.py
@@ -82,49 +82,49 @@ class TreeTests(TestCase):
     def test_simple_node(self):
         """Test that leaf expressions like ``Literal`` make the right nodes."""
         h = Literal('hello', name='greeting')
-        eq_(h.match('hello'), Node('greeting', 'hello', 0, 5))
+        eq_(h.match('hello'), Node(h, 'hello', 0, 5))
 
     def test_sequence_nodes(self):
         """Assert that ``Sequence`` produces nodes with the right children."""
         s = Sequence(Literal('heigh', name='greeting1'),
                      Literal('ho',    name='greeting2'), name='dwarf')
         text = 'heighho'
-        eq_(s.match(text), Node('dwarf', text, 0, 7, children=
-                                [Node('greeting1', text, 0, 5),
-                                 Node('greeting2', text, 5, 7)]))
+        eq_(s.match(text), Node(s, text, 0, 7, children=
+                                [Node(s.members[0], text, 0, 5),
+                                 Node(s.members[1], text, 5, 7)]))
 
     def test_one_of(self):
         """``OneOf`` should return its own node, wrapping the child that succeeds."""
         o = OneOf(Literal('a', name='lit'), name='one_of')
         text = 'aa'
-        eq_(o.match(text), Node('one_of', text, 0, 1, children=[
-                                Node('lit', text, 0, 1)]))
+        eq_(o.match(text), Node(o, text, 0, 1, children=[
+                                Node(o.members[0], text, 0, 1)]))
 
     def test_optional(self):
         """``Optional`` should return its own node wrapping the succeeded child."""
         expr = Optional(Literal('a', name='lit'), name='opt')
 
         text = 'a'
-        eq_(expr.match(text), Node('opt', text, 0, 1, children=[
-                                   Node('lit', text, 0, 1)]))
+        eq_(expr.match(text), Node(expr, text, 0, 1, children=[
+                                   Node(expr.members[0], text, 0, 1)]))
 
         # Test failure of the Literal inside the Optional; the
         # LengthTests.test_optional is ambiguous for that.
         text = ''
-        eq_(expr.match(text), Node('opt', text, 0, 0))
+        eq_(expr.match(text), Node(expr, text, 0, 0))
 
     def test_zero_or_more_zero(self):
         """Test the 0 case of ``ZeroOrMore``; it should still return a node."""
         expr = ZeroOrMore(Literal('a'), name='zero')
         text = ''
-        eq_(expr.match(text), Node('zero', text, 0, 0))
+        eq_(expr.match(text), Node(expr, text, 0, 0))
 
     def test_one_or_more_one(self):
         """Test the 1 case of ``OneOrMore``; it should return a node with a child."""
         expr = OneOrMore(Literal('a', name='lit'), name='one')
         text = 'a'
-        eq_(expr.match(text), Node('one', text, 0, 1, children=[
-                                   Node('lit', text, 0, 1)]))
+        eq_(expr.match(text), Node(expr, text, 0, 1, children=[
+                                   Node(expr.members[0], text, 0, 1)]))
 
     # Things added since Grammar got implemented are covered in integration
     # tests in test_grammar.
@@ -142,9 +142,9 @@ class ParseTests(TestCase):
         """
         expr = OneOrMore(Literal('a', name='lit'), name='more')
         text = 'aa'
-        eq_(expr.parse(text), Node('more', text, 0, 2, children=[
-                                   Node('lit', text, 0, 1),
-                                   Node('lit', text, 1, 2)]))
+        eq_(expr.parse(text), Node(expr, text, 0, 2, children=[
+                                   Node(expr.members[0], text, 0, 1),
+                                   Node(expr.members[0], text, 1, 2)]))
 
 
 class ErrorReportingTests(TestCase):

--- a/parsimonious/tests/test_nodes.py
+++ b/parsimonious/tests/test_nodes.py
@@ -80,11 +80,11 @@ def test_repr():
     n = Node(Literal(boogie), s, 0, 3, children=[
             Node(Literal(' '), s, 3, 4), Node(Literal(u'ö'), s, 4, 5)])
     eq_(repr(n),
-        """s = {hai_o}\nNode({boogie}, s, 0, 3, children=[Node({space}, s, 3, 4), Node({o}, s, 4, 5)])""".format(
+        str("""s = {hai_o}\nNode({boogie}, s, 0, 3, children=[Node({space}, s, 3, 4), Node({o}, s, 4, 5)])""").format(
             hai_o=repr(s),
             boogie=repr(Literal(boogie)),
             space=repr(Literal(" ")),
-            o=repr(Literal("ö")),
+            o=repr(Literal(u"ö")),
         )
     )
 

--- a/parsimonious/tests/test_nodes.py
+++ b/parsimonious/tests/test_nodes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from nose import SkipTest
-from nose.tools import eq_, ok_, assert_raises
+from nose.tools import eq_, ok_, assert_raises, assert_in
 
 from parsimonious import Grammar, NodeVisitor, VisitationError, rule
 from parsimonious.expressions import Literal
@@ -161,3 +161,28 @@ def test_node_inequality():
     ok_(node != None)
     ok_(node != Node(Literal('23456'), 'o hai', 0, 5))
     ok_(not (node != Node(Literal('12345'), 'o hai', 0, 5)))
+
+
+def test_generic_visit_NotImplementedError_unnamed_node():
+    class MyVisitor(NodeVisitor):
+        grammar = Grammar(r'''
+            bar = "b" "a" "r"
+        ''')
+        unwrapped_exceptions = (NotImplementedError, )
+
+    with assert_raises(NotImplementedError) as e:
+        MyVisitor().parse('bar')
+    assert_in('No visitor method was defined for "b"', str(e.exception))
+
+
+def test_generic_visit_NotImplementedError_named_node():
+    class MyVisitor(NodeVisitor):
+        grammar = Grammar(r'''
+            bar = myrule myrule myrule
+            myrule = ~"[bar]"
+        ''')
+        unwrapped_exceptions = (NotImplementedError, )
+
+    with assert_raises(NotImplementedError) as e:
+        MyVisitor().parse('bar')
+    assert_in('No visitor method was defined for myrule = ~"[bar]"', str(e.exception))

--- a/parsimonious/tests/test_nodes.py
+++ b/parsimonious/tests/test_nodes.py
@@ -34,16 +34,7 @@ class ExplosiveFormatter(NodeVisitor):
 
 
 def test_visitor():
-    """Assert a tree gets visited correctly.
-
-    We start with a tree from applying this grammar... ::
-
-
-    ...to this text::
-
-        ((o hai))
-
-    """
+    """Assert a tree gets visited correctly."""
     grammar = Grammar(r'''
         bold_text  = bold_open text bold_close
         text       = ~'[a-zA-Z 0-9]*'

--- a/parsimonious/tests/test_nodes.py
+++ b/parsimonious/tests/test_nodes.py
@@ -172,7 +172,7 @@ def test_generic_visit_NotImplementedError_unnamed_node():
 
     with assert_raises(NotImplementedError) as e:
         MyVisitor().parse('bar')
-    assert_in('No visitor method was defined for "b"', str(e.exception))
+    assert_in('No visitor method was defined for this expression: "b"', str(e.exception))
 
 
 def test_generic_visit_NotImplementedError_named_node():
@@ -185,4 +185,4 @@ def test_generic_visit_NotImplementedError_named_node():
 
     with assert_raises(NotImplementedError) as e:
         MyVisitor().parse('bar')
-    assert_in('No visitor method was defined for myrule = ~"[bar]"', str(e.exception))
+    assert_in('No visitor method was defined for this expression: myrule = ~"[bar]"', str(e.exception))

--- a/parsimonious/tests/test_nodes.py
+++ b/parsimonious/tests/test_nodes.py
@@ -164,6 +164,12 @@ def test_node_inequality():
 
 
 def test_generic_visit_NotImplementedError_unnamed_node():
+    """
+    Test that generic_visit provides informative error messages
+    when visitors are not defined.
+
+    Regression test for https://github.com/erikrose/parsimonious/issues/110
+    """
     class MyVisitor(NodeVisitor):
         grammar = Grammar(r'''
             bar = "b" "a" "r"
@@ -176,6 +182,10 @@ def test_generic_visit_NotImplementedError_unnamed_node():
 
 
 def test_generic_visit_NotImplementedError_named_node():
+    """
+    Test that generic_visit provides informative error messages
+    when visitors are not defined.
+    """
     class MyVisitor(NodeVisitor):
         grammar = Grammar(r'''
             bar = myrule myrule myrule

--- a/parsimonious/tests/test_nodes.py
+++ b/parsimonious/tests/test_nodes.py
@@ -3,6 +3,7 @@ from nose import SkipTest
 from nose.tools import eq_, ok_, assert_raises
 
 from parsimonious import Grammar, NodeVisitor, VisitationError, rule
+from parsimonious.expressions import Literal
 from parsimonious.nodes import Node
 
 
@@ -37,21 +38,24 @@ def test_visitor():
 
     We start with a tree from applying this grammar... ::
 
-        bold_text  = bold_open text bold_close
-        text       = ~'[a-zA-Z 0-9]*'
-        bold_open  = '(('
-        bold_close = '))'
 
     ...to this text::
 
         ((o hai))
 
     """
+    grammar = Grammar(r'''
+        bold_text  = bold_open text bold_close
+        text       = ~'[a-zA-Z 0-9]*'
+        bold_open  = '(('
+        bold_close = '))'
+    ''')
     text = '((o hai))'
-    tree = Node('bold_text', text, 0, 9,
-                [Node('bold_open', text, 0, 2),
-                 Node('text', text, 2, 7),
-                 Node('bold_close', text, 7, 9)])
+    tree = Node(grammar['bold_text'], text, 0, 9,
+                [Node(grammar['bold_open'], text, 0, 2),
+                 Node(grammar['text'], text, 2, 7),
+                 Node(grammar['bold_close'], text, 7, 9)])
+    eq_(grammar.parse(text), tree)
     result = HtmlFormatter().visit(tree)
     eq_(result, '<b>o hai</b>')
 
@@ -59,12 +63,12 @@ def test_visitor():
 def test_visitation_exception():
     assert_raises(VisitationError,
                   ExplosiveFormatter().visit,
-                  Node('boom', '', 0, 0))
+                  Node(Literal(''), '', 0, 0))
 
 
 def test_str():
     """Test str and unicode of ``Node``."""
-    n = Node('text', 'o hai', 0, 5)
+    n = Node(Literal('something', name='text'), 'o hai', 0, 5)
     good = '<Node called "text" matching "o hai">'
     eq_(str(n), good)
 
@@ -73,9 +77,16 @@ def test_repr():
     """Test repr of ``Node``."""
     s = u'hai ö'
     boogie = u'böogie'
-    n = Node(boogie, s, 0, 3, children=[
-            Node('', s, 3, 4), Node('', s, 4, 5)])
-    eq_(repr(n), """s = {hai_o}\nNode({boogie}, s, 0, 3, children=[Node('', s, 3, 4), Node('', s, 4, 5)])""".format(hai_o=repr(s), boogie=repr(boogie)))
+    n = Node(Literal(boogie), s, 0, 3, children=[
+            Node(Literal(' '), s, 3, 4), Node(Literal(u'ö'), s, 4, 5)])
+    eq_(repr(n),
+        """s = {hai_o}\nNode({boogie}, s, 0, 3, children=[Node({space}, s, 3, 4), Node({o}, s, 4, 5)])""".format(
+            hai_o=repr(s),
+            boogie=repr(Literal(boogie)),
+            space=repr(Literal(" ")),
+            o=repr(Literal("ö")),
+        )
+    )
 
 
 def test_parse_shortcut():
@@ -145,6 +156,8 @@ def test_unwrapped_exceptions():
 
 
 def test_node_inequality():
-    node = Node('text', 'o hai', 0, 5)
+    node = Node(Literal('12345'), 'o hai', 0, 5)
     ok_(node != 5)
     ok_(node != None)
+    ok_(node != Node(Literal('23456'), 'o hai', 0, 5))
+    ok_(not (node != Node(Literal('12345'), 'o hai', 0, 5)))

--- a/tox.ini
+++ b/tox.ini
@@ -11,4 +11,6 @@ envlist = py27, py33, py34, py35, py36
 [testenv]
 usedevelop = True
 commands = nosetests parsimonious
-deps = nose
+deps =
+  nose
+  six>=1.9.0


### PR DESCRIPTION
@erikrose Fixes #59 and #110. 

## Changes
I updated `Node` so that instead of taking an `expr_name`, it takes an `expr`. Errors now display much more nicely for anonymous nodes. For example, below is a grammar with three anonymous nodes (and to a novice, it's not obvious it contains any):
```python
from parsimonious import Grammar, NodeVisitor
class MyVisitor(NodeVisitor):
    grammar = Grammar(r'''
        default = (x x) / (y y)
        x = "x"
        y = "y"
    ''')
    def visit_x(self, node, children):
        return node.text
    def visit_y(self, node_children):
        return node.text

MyVisitor().parse('xx')
```
On the master branch, this generates the vexing error:
```pytb
>>> MyVisitor().parse('xx')
Traceback (most recent call last):
[...]
NotImplementedError: No visitor method was defined for "".
```

On this branch, it generates the following:
```pytb
>>> MyVisitor().parse('xx')
Traceback (most recent call last):
[...]
NotImplementedError: No visitor method was defined for x x.
```

### Unintended consequences
This caused the following effects, most of which had to do with the test suite:
- Many of the tests depend on equality for nodes, and this changed those semantics, so I had to add `__eq__` methods.
- Expressions are put into hash containers in a few places, and defining `__eq__` makes them non-hashable. 

Much of the work fixing these issues was in changing the test suite. This change definitely made the test suite uglier and possibly more brittle, but I think this is a large usability improvement for end users.

## Why not pass use the pre-existing repr as a name?

I considered [your suggestion](https://github.com/erikrose/parsimonious/issues/110#issuecomment-285344697) to have unnamed expressions pass their pretty repr. I decided against it for two reasons:
 1. Computing the pretty repr can be a somewhat expensive operation, so this might have performance impacts. (Minor)
 2. Nodes keeping track of the expression that matched them will allow for more intelligent visitor behavior in followup work I'd like to do.

## Still TODO
- [x] Get the python 2.7 tests passing (repr/unicode encoding issue)