### PR TITLE
Fix print statement in benchmarks

### DIFF
--- a/parsimonious/tests/benchmarks.py
+++ b/parsimonious/tests/benchmarks.py
@@ -88,6 +88,6 @@ def test_not_really_json_parsing():
     seconds_each = total_seconds / NUMBER
 
     kb = len(json) / 1024.0
-    print 'Took %.3fs to parse %.1fKB: %.0fKB/s.' % (seconds_each,
+    print('Took %.3fs to parse %.1fKB: %.0fKB/s.' % (seconds_each,
                                                      kb,
-                                                     kb / seconds_each)
+                                                     kb / seconds_each))


### PR DESCRIPTION
After this change I was capable of running this benchmark with both Python 2 and Python 3.