### PR TITLE
Fix Grammar.__repr__ backslash escaping

### DIFF
--- a/parsimonious/expressions.py
+++ b/parsimonious/expressions.py
@@ -239,8 +239,7 @@ class Literal(Expression):
             return Node(self, text, pos, pos + len(self.literal))
 
     def _as_rhs(self):
-        # TODO: Get backslash escaping right.
-        return '"%s"' % self.literal
+        return repr(self.literal)
 
 
 class TokenMatcher(Literal):
@@ -289,9 +288,8 @@ class Regex(Expression):
         return ''.join(flags[i - 1] if (1 << i) & bits else '' for i in range(1, len(flags) + 1))
 
     def _as_rhs(self):
-        # TODO: Get backslash escaping right.
-        return '~"%s"%s' % (self.re.pattern,
-                            self._regex_flags_from_bits(self.re.flags))
+        return '~{!r}{}'.format(self.re.pattern,
+                                self._regex_flags_from_bits(self.re.flags))
 
 
 class Compound(Expression):

--- a/parsimonious/grammar.py
+++ b/parsimonious/grammar.py
@@ -141,8 +141,7 @@ class Grammar(OrderedDict):
 
     def __repr__(self):
         """Return an expression that will reconstitute the grammar."""
-        codec = 'string_escape' if PY2 else 'unicode_escape'
-        return "Grammar('%s')" % str(self).encode(codec)
+        return "Grammar({!r})".format(str(self))
 
 
 class TokenGrammar(Grammar):

--- a/parsimonious/tests/test_expressions.py
+++ b/parsimonious/tests/test_expressions.py
@@ -268,19 +268,19 @@ class RepresentationTests(TestCase):
         """
         # ZeroOrMore
         eq_(text_type(Grammar('foo = "bar" ("baz" "eggs")* "spam"')),
-            u'foo = "bar" ("baz" "eggs")* "spam"')
+            u"foo = 'bar' ('baz' 'eggs')* 'spam'")
 
         # OneOf
         eq_(text_type(Grammar('foo = "bar" ("baz" / "eggs") "spam"')),
-            u'foo = "bar" ("baz" / "eggs") "spam"')
+            u"foo = 'bar' ('baz' / 'eggs') 'spam'")
 
         # Lookahead
         eq_(text_type(Grammar('foo = "bar" &("baz" "eggs") "spam"')),
-            u'foo = "bar" &("baz" "eggs") "spam"')
+            u"foo = 'bar' &('baz' 'eggs') 'spam'")
 
         # Multiple sequences
         eq_(text_type(Grammar('foo = ("bar" "baz") / ("baff" "bam")')),
-            u'foo = ("bar" "baz") / ("baff" "bam")')
+            u"foo = ('bar' 'baz') / ('baff' 'bam')")
 
     def test_unicode_surrounding_parens(self):
         """
@@ -289,7 +289,7 @@ class RepresentationTests(TestCase):
 
         """
         eq_(text_type(Grammar('foo = ("foo" ("bar" "baz"))')),
-            u'foo = "foo" ("bar" "baz")')
+            u"foo = 'foo' ('bar' 'baz')")
 
 
 class SlotsTests(TestCase):

--- a/parsimonious/tests/test_expressions.py
+++ b/parsimonious/tests/test_expressions.py
@@ -291,6 +291,26 @@ class RepresentationTests(TestCase):
         eq_(text_type(Grammar('foo = ("foo" ("bar" "baz"))')),
             u"foo = 'foo' ('bar' 'baz')")
 
+    def test_repr_special_character_escaping(self):
+        """Make sure special characters are properly escaped in the repr.
+
+        """
+
+        # backslash
+        eq_(repr(Grammar(r'''foo = "\\" ''')), u'''Grammar("foo = '\\\\\\\\'")''')
+
+        # single quote
+        eq_(repr(Grammar(r'''foo = "'" ''')), u'''Grammar('foo = "\\'"')''')
+
+        # escaped single quote inside a single quoted string
+        eq_(repr(Grammar(r'''foo = '\'' ''')), u'''Grammar('foo = "\\'"')''')
+
+        # double quote
+        eq_(repr(Grammar(r'''foo = '"' ''')), u'''Grammar('foo = \\'"\\'')''')
+
+        # newline
+        eq_(repr(Grammar(r'''foo = "\n" ''')), u'''Grammar("foo = '\\\\n'")''')
+
 
 class SlotsTests(TestCase):
     """Tests to do with __slots__"""

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -167,10 +167,10 @@ class GrammarTests(TestCase):
                           """)
         lines = text_type(grammar).splitlines()
         eq_(lines[0], 'bold_text = bold_open text bold_close')
-        ok_('text = ~"[A-Z 0-9]*"i%s' % ('u' if version_info >= (3,) else '')
+        ok_("text = ~'[A-Z 0-9]*'i%s" % ('u' if version_info >= (3,) else '')
             in lines)
-        ok_('bold_open = "(("' in lines)
-        ok_('bold_close = "))"' in lines)
+        ok_("bold_open = '(('" in lines)
+        ok_("bold_close = '))'" in lines)
         eq_(len(lines), 4)
 
     def test_match(self):
@@ -208,8 +208,8 @@ class GrammarTests(TestCase):
             ['''bold_text = stars text stars''',
              # TODO: Unicode flag is on by default in Python 3. I wonder if we
              # should turn it on all the time in Parsimonious.
-             '''stars = "**"''',
-             '''text = ~"[A-Z 0-9]*"i%s''' % ('u' if version_info >= (3,)
+             """stars = '**'""",
+             '''text = ~'[A-Z 0-9]*'i%s''' % ('u' if version_info >= (3,)
                                               else '')])
 
     def test_multi_line(self):

--- a/parsimonious/tests/test_nodes.py
+++ b/parsimonious/tests/test_nodes.py
@@ -169,7 +169,7 @@ def test_generic_visit_NotImplementedError_unnamed_node():
 
     with assert_raises(NotImplementedError) as e:
         MyVisitor().parse('bar')
-    assert_in('No visitor method was defined for this expression: "b"', str(e.exception))
+    assert_in("No visitor method was defined for this expression: 'b'", str(e.exception))
 
 
 def test_generic_visit_NotImplementedError_named_node():
@@ -186,4 +186,4 @@ def test_generic_visit_NotImplementedError_named_node():
 
     with assert_raises(NotImplementedError) as e:
         MyVisitor().parse('bar')
-    assert_in('No visitor method was defined for this expression: myrule = ~"[bar]"', str(e.exception))
+    assert_in("No visitor method was defined for this expression: myrule = ~'[bar]'", str(e.exception))


### PR DESCRIPTION
Fixes the backslash escaping by making use of python's own string representations.

It has the side-effect that `'` will usually be preferred over `"` when printing literals. This affects several tests, which had to be updated.