### PR TITLE
Support functions, class methods, and descriptors for custom rules

### DIFF
--- a/parsimonious/expressions.py
+++ b/parsimonious/expressions.py
@@ -70,6 +70,7 @@ def expression(callable, rule_name, grammar):
 
     num_args = len(getargspec(callable).args)
     if ismethod(callable):
+        # do not count the first argument (typically 'self') for methods
         num_args -= 1
     if num_args == 2:
         is_simple = True

--- a/parsimonious/grammar.py
+++ b/parsimonious/grammar.py
@@ -6,14 +6,13 @@ by hand.
 
 """
 from collections import OrderedDict
-from inspect import isfunction, ismethod
 
 from six import (text_type, itervalues, iteritems, python_2_unicode_compatible, PY2)
 
 from parsimonious.exceptions import BadGrammar, UndefinedLabel
 from parsimonious.expressions import (Literal, Regex, Sequence, OneOf,
     Lookahead, Optional, ZeroOrMore, OneOrMore, Not, TokenMatcher,
-    expression)
+    expression, is_callable)
 from parsimonious.nodes import NodeVisitor
 from parsimonious.utils import evaluate_string
 
@@ -63,7 +62,7 @@ class Grammar(OrderedDict):
         """
 
         decorated_custom_rules = {
-            k: (expression(v, k, self) if isfunction(v) or ismethod(v) else v)
+            k: (expression(v, k, self) if is_callable(v) else v)
             for k, v in iteritems(more_rules)}
 
         exprs, first = self._expressions_from_rules(rules, decorated_custom_rules)

--- a/parsimonious/tests/test_expressions.py
+++ b/parsimonious/tests/test_expressions.py
@@ -6,7 +6,7 @@ from six import text_type
 
 from parsimonious.exceptions import ParseError, IncompleteParseError
 from parsimonious.expressions import (Literal, Regex, Sequence, OneOf, Not,
-    Optional, ZeroOrMore, OneOrMore, Expression, is_callable)
+    Optional, ZeroOrMore, OneOrMore, Expression)
 from parsimonious.grammar import Grammar, rule_grammar
 from parsimonious.nodes import Node
 
@@ -70,47 +70,6 @@ class LengthTests(TestCase):
         len_eq(OneOrMore(Literal('b'), min=3).match('bbb'), 3)  # with custom min; success
         assert_raises(ParseError, OneOrMore(Literal('b'), min=3).match, 'bb')  # with custom min; failure
         len_eq(OneOrMore(Regex('^')).match('bb'), 0)  # attempt infinite loop
-
-
-def function_rule(text, pos):
-    token = 'function'
-    return pos + len(token) if text[pos:].startswith(token) else None
-
-
-class CustomRuleTests(TestCase):
-    """Tests for parsing custom rule expressions"""
-
-    class CustomRuleClass():
-
-        def method_rule(text, pos):
-            token = 'method'
-            return pos + len(token) if text[pos:].startswith(token) else None
-
-        @staticmethod
-        def descriptor_rule(text, pos):
-            token = 'descriptor'
-            return pos + len(token) if text[pos:].startswith(token) else None
-
-        grammar = Grammar("""
-            default = (token space?)+
-            space = " "
-            token
-            = function
-            / method
-            / descriptor
-            """,
-            function=function_rule,
-            method=method_rule,
-            descriptor=descriptor_rule,
-        )
-
-    def test_parsing(self):
-        self.CustomRuleClass.grammar.parse("function method descriptor")
-
-    def test_is_callable(self):
-        ok_(is_callable(function_rule))
-        ok_(is_callable(self.CustomRuleClass.method_rule))
-        ok_(is_callable(self.CustomRuleClass.descriptor_rule))
 
 
 class TreeTests(TestCase):

--- a/parsimonious/tests/test_expressions.py
+++ b/parsimonious/tests/test_expressions.py
@@ -6,7 +6,7 @@ from six import text_type
 
 from parsimonious.exceptions import ParseError, IncompleteParseError
 from parsimonious.expressions import (Literal, Regex, Sequence, OneOf, Not,
-    Optional, ZeroOrMore, OneOrMore, Expression)
+    Optional, ZeroOrMore, OneOrMore, Expression, is_callable)
 from parsimonious.grammar import Grammar, rule_grammar
 from parsimonious.nodes import Node
 
@@ -70,6 +70,47 @@ class LengthTests(TestCase):
         len_eq(OneOrMore(Literal('b'), min=3).match('bbb'), 3)  # with custom min; success
         assert_raises(ParseError, OneOrMore(Literal('b'), min=3).match, 'bb')  # with custom min; failure
         len_eq(OneOrMore(Regex('^')).match('bb'), 0)  # attempt infinite loop
+
+
+def function_rule(text, pos):
+    token = 'function'
+    return pos + len(token) if text[pos:].startswith(token) else None
+
+
+class CustomRuleTests(TestCase):
+    """Tests for parsing custom rule expressions"""
+
+    class CustomRuleClass():
+
+        def method_rule(text, pos):
+            token = 'method'
+            return pos + len(token) if text[pos:].startswith(token) else None
+
+        @staticmethod
+        def descriptor_rule(text, pos):
+            token = 'descriptor'
+            return pos + len(token) if text[pos:].startswith(token) else None
+
+        grammar = Grammar("""
+            default = (token space?)+
+            space = " "
+            token
+            = function
+            / method
+            / descriptor
+            """,
+            function=function_rule,
+            method=method_rule,
+            descriptor=descriptor_rule,
+        )
+
+    def test_parsing(self):
+        self.CustomRuleClass.grammar.parse("function method descriptor")
+
+    def test_is_callable(self):
+        ok_(is_callable(function_rule))
+        ok_(is_callable(self.CustomRuleClass.method_rule))
+        ok_(is_callable(self.CustomRuleClass.descriptor_rule))
 
 
 class TreeTests(TestCase):

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -140,6 +140,8 @@ class RuleVisitorTests(TestCase):
 
 
 def function_rule(text, pos):
+    """This is an example of a grammar rule implemented as a function, and is
+    provided as a test fixture."""
     token = 'function'
     return pos + len(token) if text[pos:].startswith(token) else None
 
@@ -148,11 +150,15 @@ class GrammarTests(TestCase):
     """Integration-test ``Grammar``: feed it a PEG and see if it works."""
 
     def method_rule(self, text, pos):
+        """This is an example of a grammar rule implemented as a method, and is
+        provided as a test fixture."""
         token = 'method'
         return pos + len(token) if text[pos:].startswith(token) else None
 
     @staticmethod
     def descriptor_rule(text, pos):
+        """This is an example of a grammar rule implemented as a descriptor,
+        and is provided as a test fixture."""
         token = 'descriptor'
         return pos + len(token) if text[pos:].startswith(token) else None
 

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -156,7 +156,7 @@ class GrammarTests(TestCase):
         token = 'descriptor'
         return pos + len(token) if text[pos:].startswith(token) else None
 
-    rules = {"descriptor": descriptor_rule}
+    rules = {"descriptor_rule": descriptor_rule}
 
     def test_expressions_from_rules(self):
         """Test the ``Grammar`` base class's ability to compile an expression
@@ -397,7 +397,7 @@ class GrammarTests(TestCase):
     def test_callability_of_routines(self):
         ok_(is_callable(function_rule))
         ok_(is_callable(self.method_rule))
-        ok_(is_callable(self.rules["descriptor"]))
+        ok_(is_callable(self.rules["descriptor_rule"]))
 
     def test_callability_custom_rules(self):
         """Confirms that functions, methods and method descriptors can all be
@@ -408,7 +408,7 @@ class GrammarTests(TestCase):
             """,
             function=function_rule,
             method=self.method_rule,
-            descriptor=self.rules["descriptor"],
+            descriptor=self.rules["descriptor_rule"],
         )
         result = grammar.parse('functionmethoddescriptor')
         rule_names = [node.expr.name for node in result.children]

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -9,7 +9,7 @@ from nose.tools import eq_, assert_raises, ok_
 from six import text_type
 
 from parsimonious.exceptions import UndefinedLabel, ParseError
-from parsimonious.expressions import Literal, Lookahead, Regex, Sequence, TokenMatcher
+from parsimonious.expressions import Literal, Lookahead, Regex, Sequence, TokenMatcher, is_callable
 from parsimonious.grammar import rule_grammar, RuleVisitor, Grammar, TokenGrammar, LazyReference
 from parsimonious.nodes import Node
 from parsimonious.utils import Token
@@ -391,6 +391,11 @@ class GrammarTests(TestCase):
         s = '4'
         eq_(grammar.parse(s),
             Node(grammar['one_char'], s, 0, 1))
+
+    def test_callability_of_routines(self):
+        ok_(is_callable(function_rule))
+        ok_(is_callable(self.method_rule))
+        ok_(is_callable(self.descriptor_rule))
 
     def test_callability_custom_rules(self):
         """Confirms that functions, methods and method descriptors can all be

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -156,6 +156,8 @@ class GrammarTests(TestCase):
         token = 'descriptor'
         return pos + len(token) if text[pos:].startswith(token) else None
 
+    rules = {"descriptor": descriptor_rule}
+
     def test_expressions_from_rules(self):
         """Test the ``Grammar`` base class's ability to compile an expression
         tree from rules.
@@ -406,7 +408,7 @@ class GrammarTests(TestCase):
             """,
             function=function_rule,
             method=self.method_rule,
-            descriptor=self.descriptor_rule,
+            descriptor=self.rules["descriptor"],
         )
         result = grammar.parse('functionmethoddescriptor')
         rule_names = [node.expr.name for node in result.children]

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -397,7 +397,7 @@ class GrammarTests(TestCase):
     def test_callability_of_routines(self):
         ok_(is_callable(function_rule))
         ok_(is_callable(self.method_rule))
-        ok_(is_callable(self.rules["descriptor_rule"]))
+        ok_(is_callable(self.rules['descriptor_rule']))
 
     def test_callability_custom_rules(self):
         """Confirms that functions, methods and method descriptors can all be
@@ -408,7 +408,7 @@ class GrammarTests(TestCase):
             """,
             function=function_rule,
             method=self.method_rule,
-            descriptor=self.rules["descriptor_rule"],
+            descriptor=self.rules['descriptor_rule'],
         )
         result = grammar.parse('functionmethoddescriptor')
         rule_names = [node.expr.name for node in result.children]

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -397,7 +397,7 @@ class GrammarTests(TestCase):
     def test_callability_of_routines(self):
         ok_(is_callable(function_rule))
         ok_(is_callable(self.method_rule))
-        ok_(is_callable(self.descriptor_rule))
+        ok_(is_callable(self.rules["descriptor"]))
 
     def test_callability_custom_rules(self):
         """Confirms that functions, methods and method descriptors can all be


### PR DESCRIPTION
This PR is to handle a fairly specific scenario where a `Grammar` is defined inside a Python class, and refers to custom rules which are static methods on that class.

In `parsimonious==0.8.1`, attempting the following will fail:

```python
class ExampleParser():
    @staticmethod
    def custom_rule(text, pos):
        pass

    grammar = Grammar("""
        ...
        """,
        custom_rule=custom_rule
    )
```

The failure occurs when an exception is raised during [creation of the rule map](https://github.com/erikrose/parsimonious/blob/0.8.1/parsimonious/grammar.py#L452-L453), and the root cause is that the reference to `custom_rule` is resolved by Python as an [unbound method descriptor](https://stackoverflow.com/questions/41921255/staticmethod-object-is-not-callable).

This PR resolves the issue by adding a specific check to see if a rule matches the `inspect.ismethoddescriptor` check; if it does, we also need to retrieve the `__func__` value from the reference in order to obtain a Python `callable`.

The PR also handles a similar case where a (non-static) class method is bound to a custom rule, but an argument count mismatch occurs due to the presence of the instance `self` argument in object method calls.

Edits: enable syntax highlighting, fix indenting, make syntactically valid