### PR TITLE
Use regex module instead of builtin re module

### DIFF
--- a/parsimonious/expressions.py
+++ b/parsimonious/expressions.py
@@ -7,7 +7,7 @@ These do the parsing.
 # anything--for speed. And kill all the dots.
 
 from inspect import getargspec, isfunction, ismethod, ismethoddescriptor
-import re
+import regex as re
 
 from six import integer_types, python_2_unicode_compatible
 from six.moves import range

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
     test_suite='nose.collector',
     url='https://github.com/erikrose/parsimonious',
     include_package_data=True,
-    install_requires=['six>=1.9.0'],
+    install_requires=['six>=1.9.0', 'regex>=2020.11.13'],
     classifiers=[
         'Intended Audience :: Developers',
         'Natural Language :: English',


### PR DESCRIPTION
The regex module implements more regex features than the builtin re module.