### PR TITLE
fix issue #192 - remove six and python 2 compatability code 

### DIFF
--- a/parsimonious/exceptions.py
+++ b/parsimonious/exceptions.py
@@ -1,9 +1,7 @@
-from six import text_type, python_2_unicode_compatible
 
 from parsimonious.utils import StrAndRepr
 
 
-@python_2_unicode_compatible
 class ParseError(StrAndRepr, Exception):
     """A call to ``Expression.parse()`` or ``match()`` didn't match."""
 
@@ -17,7 +15,7 @@ class ParseError(StrAndRepr, Exception):
 
     def __str__(self):
         rule_name = ((u"'%s'" % self.expr.name) if self.expr.name else
-                     text_type(self.expr))
+                     str(self.expr))
         return u"Rule %s didn't match at '%s' (line %s, column %s)." % (
                 rule_name,
                 self.text[self.pos:self.pos + 20],
@@ -43,7 +41,6 @@ class ParseError(StrAndRepr, Exception):
             return self.pos + 1
 
 
-@python_2_unicode_compatible
 class IncompleteParseError(ParseError):
     """A call to ``parse()`` matched a whole Expression but did not consume the
     entire text."""
@@ -94,7 +91,6 @@ class BadGrammar(StrAndRepr, Exception):
     """
 
 
-@python_2_unicode_compatible
 class UndefinedLabel(BadGrammar):
     """A rule referenced in a grammar was never defined.
 

--- a/parsimonious/expressions.py
+++ b/parsimonious/expressions.py
@@ -9,9 +9,6 @@ These do the parsing.
 from inspect import getargspec, isfunction, ismethod, ismethoddescriptor
 import re
 
-from six import integer_types, python_2_unicode_compatible
-from six.moves import range
-
 from parsimonious.exceptions import ParseError, IncompleteParseError
 from parsimonious.nodes import Node, RegexNode
 from parsimonious.utils import StrAndRepr
@@ -85,7 +82,7 @@ def expression(callable, rule_name, grammar):
             result = (callable(text, pos) if is_simple else
                       callable(text, pos, cache, error, grammar))
 
-            if isinstance(result, integer_types):
+            if isinstance(result, int):
                 end, children = result, None
             elif isinstance(result, tuple):
                 end, children = result
@@ -100,7 +97,6 @@ def expression(callable, rule_name, grammar):
     return AdHocExpression(name=rule_name)
 
 
-@python_2_unicode_compatible
 class Expression(StrAndRepr):
     """A thing that can be matched against a piece of text"""
 

--- a/parsimonious/grammar.py
+++ b/parsimonious/grammar.py
@@ -7,8 +7,6 @@ by hand.
 """
 from collections import OrderedDict
 
-from six import (text_type, itervalues, iteritems, python_2_unicode_compatible, PY2)
-
 from parsimonious.exceptions import BadGrammar, UndefinedLabel
 from parsimonious.expressions import (Literal, Regex, Sequence, OneOf,
     Lookahead, Optional, ZeroOrMore, OneOrMore, Not, TokenMatcher,
@@ -16,7 +14,6 @@ from parsimonious.expressions import (Literal, Regex, Sequence, OneOf,
 from parsimonious.nodes import NodeVisitor
 from parsimonious.utils import evaluate_string
 
-@python_2_unicode_compatible
 class Grammar(OrderedDict):
     """A collection of rules that describe a language
 
@@ -63,7 +60,7 @@ class Grammar(OrderedDict):
 
         decorated_custom_rules = {
             k: (expression(v, k, self) if is_callable(v) else v)
-            for k, v in iteritems(more_rules)}
+            for k, v in more_rules.items()}
 
         exprs, first = self._expressions_from_rules(rules, decorated_custom_rules)
         super(Grammar, self).__init__(exprs.items())
@@ -84,7 +81,7 @@ class Grammar(OrderedDict):
 
         """
         new = Grammar.__new__(Grammar)
-        super(Grammar, new).__init__(iteritems(self))
+        super(Grammar, new).__init__(self.items())
         new.default_rule = self.default_rule
         return new
 
@@ -134,7 +131,7 @@ class Grammar(OrderedDict):
         """Return a rule string that, when passed to the constructor, would
         reconstitute the grammar."""
         exprs = [self.default_rule] if self.default_rule else []
-        exprs.extend(expr for expr in itervalues(self) if
+        exprs.extend(expr for expr in self.values() if
                      expr is not self.default_rule)
         return '\n'.join(expr.as_rule() for expr in exprs)
 
@@ -258,7 +255,7 @@ rule_syntax = (r'''
     ''')
 
 
-class LazyReference(text_type):
+class LazyReference(str):
     """A lazy reference to a rule, which we resolve after grokking all the
     rules"""
 
@@ -407,7 +404,7 @@ class RuleVisitor(NodeVisitor):
 
         """
         if isinstance(expr, LazyReference):
-            label = text_type(expr)
+            label = str(expr)
             try:
                 reffed_expr = rule_map[label]
             except KeyError:
@@ -449,7 +446,7 @@ class RuleVisitor(NodeVisitor):
         # Resolve references. This tolerates forward references.
         done = set()
         rule_map = OrderedDict((expr.name, self._resolve_refs(rule_map, expr, done))
-                               for expr in itervalues(rule_map))
+                               for expr in rule_map.values())
 
         # isinstance() is a temporary hack around the fact that * rules don't
         # always get transformed into lists by NodeVisitor. We should fix that;

--- a/parsimonious/nodes.py
+++ b/parsimonious/nodes.py
@@ -216,11 +216,11 @@ class NodeVisitor(object):
         except (VisitationError, UndefinedLabel):
             # Don't catch and re-wrap already-wrapped exceptions.
             raise
-        except self.unwrapped_exceptions:
-            raise
         except Exception as e:
-            # Catch any exception, and tack on a parse tree so it's easier to
-            # see where it went wrong.
+            # implentors may define exception classes that should not be
+            # wrapped.
+            if isinstance(e, self.unwrapped_exceptions):
+                raise
             raise VisitationError from e
 
     def generic_visit(self, node, visited_children):

--- a/parsimonious/nodes.py
+++ b/parsimonious/nodes.py
@@ -154,7 +154,7 @@ class RuleDecoratorMeta(type):
                      metaclass).__new__(metaclass, name, bases, namespace)
 
 
-class NodeVisitor(object):
+class NodeVisitor(object, metaclass=RuleDecoratorMeta):
     """A shell for writing things that turn parse trees into something useful
 
     Performs a depth-first traversal of an AST. Subclass this, add methods for
@@ -177,8 +177,6 @@ class NodeVisitor(object):
       Heaven forbid you're making it into a string or something else.
 
     """
-
-    __metaclass__ = RuleDecoratorMeta
 
     #: The :term:`default grammar`: the one recommended for use with this
     #: visitor. If you populate this, you will be able to call

--- a/parsimonious/nodes.py
+++ b/parsimonious/nodes.py
@@ -216,12 +216,15 @@ class NodeVisitor(object):
         except (VisitationError, UndefinedLabel):
             # Don't catch and re-wrap already-wrapped exceptions.
             raise
-        except Exception as e:
+        except Exception as exc:
             # implentors may define exception classes that should not be
             # wrapped.
-            if isinstance(e, self.unwrapped_exceptions):
+            if isinstance(exc, self.unwrapped_exceptions):
                 raise
-            raise VisitationError from e
+            # Catch any exception, and tack on a parse tree so it's easier to
+            # see where it went wrong.
+            exc_class = type(exc)
+            raise VisitationError(exc, exc_class, node)
 
     def generic_visit(self, node, visited_children):
         """Default visitor method

--- a/parsimonious/tests/test_expressions.py
+++ b/parsimonious/tests/test_expressions.py
@@ -1,8 +1,6 @@
 # coding=utf-8
 from unittest import TestCase
 
-from six import text_type
-
 from parsimonious.exceptions import ParseError, IncompleteParseError
 from parsimonious.expressions import (Literal, Regex, Sequence, OneOf, Not,
                                       Optional, ZeroOrMore, OneOrMore, Expression)
@@ -169,7 +167,7 @@ class ErrorReportingTests(TestCase):
             self.assertEqual(error.pos, 6)
             self.assertEqual(error.expr, grammar['close_parens'])
             self.assertEqual(error.text, text)
-            self.assertEqual(text_type(error), "Rule 'close_parens' didn't match at '!!' (line 1, column 7).")
+            self.assertEqual(str(error), "Rule 'close_parens' didn't match at '!!' (line 1, column 7).")
 
     def test_rewinding(self):
         """Make sure rewinding the stack and trying an alternative (which
@@ -215,7 +213,7 @@ class ErrorReportingTests(TestCase):
         try:
             grammar.parse('chitty bangbang')
         except IncompleteParseError as error:
-            self.assertEqual(text_type(
+            self.assertEqual(str(
                 error), u"Rule 'sequence' matched in its entirety, but it didn't consume all the text. The non-matching portion of the text begins with 'bang' (line 1, column 12).")
 
     def test_favoring_named_rules(self):
@@ -226,7 +224,7 @@ class ErrorReportingTests(TestCase):
         try:
             grammar.parse('burp')
         except ParseError as error:
-            self.assertEqual(text_type(error), u"Rule 'starts_with_a' didn't match at 'burp' (line 1, column 1).")
+            self.assertEqual(str(error), u"Rule 'starts_with_a' didn't match at 'burp' (line 1, column 1).")
 
     def test_line_and_column(self):
         """Make sure we got the line and column computation right."""
@@ -240,7 +238,7 @@ class ErrorReportingTests(TestCase):
         except ParseError as error:
             # TODO: Right now, this says "Rule <Literal "\n" at 0x4368250432>
             # didn't match". That's not the greatest. Fix that, then fix this.
-            self.assertTrue(text_type(error).endswith(r"""didn't match at 'GOO' (line 2, column 4)."""))
+            self.assertTrue(str(error).endswith(r"""didn't match at 'GOO' (line 2, column 4)."""))
 
 
 class RepresentationTests(TestCase):
@@ -258,7 +256,7 @@ class RepresentationTests(TestCase):
         ``GrammarTests.test_unicode``.
 
         """
-        text_type(rule_grammar)
+        str(rule_grammar)
 
     def test_unicode_keep_parens(self):
         """Make sure converting an expression to unicode doesn't strip
@@ -266,19 +264,19 @@ class RepresentationTests(TestCase):
 
         """
         # ZeroOrMore
-        self.assertEqual(text_type(Grammar('foo = "bar" ("baz" "eggs")* "spam"')),
+        self.assertEqual(str(Grammar('foo = "bar" ("baz" "eggs")* "spam"')),
                          u"foo = 'bar' ('baz' 'eggs')* 'spam'")
 
         # OneOf
-        self.assertEqual(text_type(Grammar('foo = "bar" ("baz" / "eggs") "spam"')),
+        self.assertEqual(str(Grammar('foo = "bar" ("baz" / "eggs") "spam"')),
                          u"foo = 'bar' ('baz' / 'eggs') 'spam'")
 
         # Lookahead
-        self.assertEqual(text_type(Grammar('foo = "bar" &("baz" "eggs") "spam"')),
+        self.assertEqual(str(Grammar('foo = "bar" &("baz" "eggs") "spam"')),
                          u"foo = 'bar' &('baz' 'eggs') 'spam'")
 
         # Multiple sequences
-        self.assertEqual(text_type(Grammar('foo = ("bar" "baz") / ("baff" "bam")')),
+        self.assertEqual(str(Grammar('foo = ("bar" "baz") / ("baff" "bam")')),
                          u"foo = ('bar' 'baz') / ('baff' 'bam')")
 
     def test_unicode_surrounding_parens(self):
@@ -287,7 +285,7 @@ class RepresentationTests(TestCase):
         right-hand side of an expression (as they're unnecessary).
 
         """
-        self.assertEqual(text_type(Grammar('foo = ("foo" ("bar" "baz"))')),
+        self.assertEqual(str(Grammar('foo = ("foo" ("bar" "baz"))')),
                          u"foo = 'foo' ('bar' 'baz')")
 
 

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -4,7 +4,6 @@ from sys import version_info
 from unittest import TestCase
 
 import sys
-from six import text_type
 
 from parsimonious.exceptions import UndefinedLabel, ParseError
 from parsimonious.expressions import Literal, Lookahead, Regex, Sequence, TokenMatcher, is_callable
@@ -185,7 +184,7 @@ class GrammarTests(TestCase):
                           bold_open  = "(("
                           bold_close = "))"
                           """)
-        lines = text_type(grammar).splitlines()
+        lines = str(grammar).splitlines()
         self.assertEqual(lines[0], 'bold_text = bold_open text bold_close')
         self.assertTrue("text = ~'[A-Z 0-9]*'i%s" % ('u' if version_info >= (3,) else '')
             in lines)

--- a/parsimonious/utils.py
+++ b/parsimonious/utils.py
@@ -2,8 +2,6 @@
 
 import ast
 
-from six import python_2_unicode_compatible
-
 
 class StrAndRepr(object):
     """Mix-in which gives the class the same __repr__ and __str__."""
@@ -21,7 +19,6 @@ def evaluate_string(string):
     return ast.literal_eval(string)
 
 
-@python_2_unicode_compatible
 class Token(StrAndRepr):
     """A class to represent tokens, for use with TokenGrammars
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
     test_suite='tests',
     url='https://github.com/erikrose/parsimonious',
     include_package_data=True,
-    install_requires=['six>=1.9.0'],
     classifiers=[
         'Intended Audience :: Developers',
         'Natural Language :: English',

--- a/tox.ini
+++ b/tox.ini
@@ -13,4 +13,3 @@ usedevelop = True
 commands = py.test
 deps =
   pytest
-  six>=1.9.0


### PR DESCRIPTION
parsimonious is all-in on python 3, so six can be removed.

Most of the changes are simple replacements, but there are a few more complicated replacements:

* catching `unwrapped_exceptions` was moved into the general `except Exception` block because python 3 does not allow `except tuple[()]` though python 2 did. see parsimonious/nodes.py:217 

* python 3 totally changed how retrieving exception info and reraising works. The code is much simpler than was six required, involving fewer intermediary variables. see parsimonious/nodes.py:225

* six documentation suggests using the `__metaclass__` property to set a metaclass, which did not work. The python 3 reference suggested using the `metaclass=MyClass` keyword, which works  well.

`$ tox` passes locally for me across all versions. Travis-CI is failing to install or run anything in the python 3.10 environment, though the other environments pass

