### PR TITLE
eliminate warnings in the test runner

### DIFF
--- a/parsimonious/expressions.py
+++ b/parsimonious/expressions.py
@@ -6,7 +6,7 @@ These do the parsing.
 # TODO: Make sure all symbol refs are local--not class lookups or
 # anything--for speed. And kill all the dots.
 
-from inspect import getargspec, isfunction, ismethod, ismethoddescriptor
+from inspect import getfullargspec, isfunction, ismethod, ismethoddescriptor
 import re
 
 from parsimonious.exceptions import ParseError, IncompleteParseError
@@ -65,7 +65,7 @@ def expression(callable, rule_name, grammar):
     if ismethoddescriptor(callable) and hasattr(callable, '__func__'):
         callable = callable.__func__
 
-    num_args = len(getargspec(callable).args)
+    num_args = len(getfullargspec(callable).args)
     if ismethod(callable):
         # do not count the first argument (typically 'self') for methods
         num_args -= 1

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,5 @@
 from sys import version_info
 
-# Prevent spurious errors during `python setup.py test` in 2.6, a la
-# http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html:
-try:
-    import multiprocessing
-except ImportError:
-    pass
-
 from io import open
 from setuptools import setup, find_packages
 
@@ -21,8 +14,6 @@ setup(
     author_email='erikrose@grinchcentral.com',
     license='MIT',
     packages=find_packages(exclude=['ez_setup']),
-    setup_requires=['pytest-runner'],
-    tests_require=['pytest'],
     test_suite='tests',
     url='https://github.com/erikrose/parsimonious',
     include_package_data=True,


### PR DESCRIPTION
`getargspec()` is deprecated. `getfullargspec()` is supposed to be a drop in replacement for most use cases, expanding the return value of `getargspec()` to include function annotations and keyword-only parameters. The exact behavior changed in 3.6 and again in 3.7, so if this becomes a problem look into directly calling `signature()`, which underlies `getfullargspec()`, in order to build exactly what is needed.

Commit https://github.com/erikrose/parsimonious/commit/67d92ef5b1f81ca1b43ab467fcd8822e2a6277f9 resolves the warnings captured during test runs, such that there is no longer a warnings summary or warnings listen in the overall test summary.

There remains, however, another warning that occurs outside of pytest that is displayed in the tox output, about a planned and upcoming change in setuptools.

`pytest-runner` is the source of the warning. It has a deprecation notice that recommends avoiding `setup_requires` and `test_requires` in `setup.py`. Since Parsimonious no longer supports python 2.x, we can remove `pytest-runner` and the associated fields of `setup.py`. `tox.ini` contains the necessary information to setup and run the test environment for Python 3.x versions. While we're there we may as well also remove the `import multiprocess` hack for python 2.6.