### PR TITLE
Binary grammars and string literal precedence fix 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -432,6 +432,11 @@ Niceties
 
 Version History
 ===============
+(Next release)
+  * Add support for grammars on bytestrings (lucaswiman)
+  * Fix precedence of string literal modifiers u/r/b.
+    This will break grammars with no spaces between a
+	reference and a string literal. (lucaswiman)
 
 0.9.0
   * Add support for Python 3.7, 3.8, 3.9, 3.10 (righthandabacus, Lonnen)

--- a/README.rst
+++ b/README.rst
@@ -236,6 +236,14 @@ Syntax Reference
                         conventions for "raw" and Unicode strings help support
                         fiddly characters.
 
+``b"some literal"``     A bytes literal. Using bytes literals and regular
+                        expressions allows your grammar to parse binary files.
+						Note that all literals and regular expressions must be
+						of the same type within a grammar. In grammars that
+						process bytestrings, you should make the grammar string
+						an ``r"""string"""`` so that byte literals like ``\xff``
+						work correctly.
+
 [space]                 Sequences are made out of space- or tab-delimited
                         things. ``a b c`` matches spots where those 3
                         terms appear in that order.
@@ -268,6 +276,9 @@ Syntax Reference
                         regexes and instead have Parsimonious dynamically build
                         them out of simpler primitives. Parsimonious uses the
                         regex_ library instead of the built-in re module.
+
+``~br"regex"``          A bytes regex; required if your grammar parses
+                        bytestrings.
 
 ``(things)``            Parentheses are used for grouping, like in every other
                         language.

--- a/parsimonious/grammar.py
+++ b/parsimonious/grammar.py
@@ -246,7 +246,7 @@ rule_syntax = (r'''
     # A subsequent equal sign is the only thing that distinguishes a label
     # (which begins a new rule) from a reference (which is just a pointer to a
     # rule defined somewhere else):
-    label = ~"[a-zA-Z_][a-zA-Z_0-9]*" _
+    label = ~"[a-zA-Z_][a-zA-Z_0-9]*(?![\"'])" _
 
     # _ = ~r"\s*(?:#[^\r\n]*)?\s*"
     _ = meaninglessness*

--- a/parsimonious/grammar.py
+++ b/parsimonious/grammar.py
@@ -226,8 +226,8 @@ rule_syntax = (r'''
     literal = spaceless_literal _
 
     # So you can't spell a regex like `~"..." ilm`:
-    spaceless_literal = ~"u?r?\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\""is /
-                        ~"u?r?'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'"is
+    spaceless_literal = ~"u?r?b?\"[^\"\\\\]*(?:\\\\.[^\"\\\\]*)*\""is /
+                        ~"u?r?b?'[^'\\\\]*(?:\\\\.[^'\\\\]*)*'"is
 
     expression = ored / sequence / term
     or_term = "/" _ term

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -518,7 +518,7 @@ def test_binary_grammar():
     g = Grammar(r"""
         file = header body terminator
         header = b"\xFF" length b"~"
-        length = ~b"\d+"
+        length = ~rb"\d+"
         body = ~b"[^\xFF]*"
         terminator = b"\xFF"
     """)

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -512,3 +512,15 @@ def test_precedence_of_string_modifiers():
         escaped_bell = r"\b"
     """)
     assert g2.parse("\\b")
+
+
+def test_binary_grammar():
+    g = Grammar(r"""
+        file = header body terminator
+        header = b"\xFF" length b"~"
+        length = ~b"\d+"
+        body = ~b"[^\xFF]*"
+        terminator = b"\xFF"
+    """)
+    length = 22
+    assert g.parse(b"\xff22~" + (b"a" * 22) + b"\xff") is not None

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 import sys
 import pytest
 
-from parsimonious.exceptions import UndefinedLabel, ParseError, VisitationError
+from parsimonious.exceptions import BadGrammar, UndefinedLabel, ParseError, VisitationError
 from parsimonious.expressions import Literal, Lookahead, Regex, Sequence, TokenMatcher, is_callable
 from parsimonious.grammar import rule_grammar, RuleVisitor, Grammar, TokenGrammar, LazyReference
 from parsimonious.nodes import Node
@@ -532,13 +532,16 @@ def test_inconsistent_string_types_in_grammar():
             foo = b"foo"
             bar = "bar"
         """)
-    assert str(e.value).startswith("BadGrammar:")
+    assert e.value.original_class is BadGrammar
     with pytest.raises(VisitationError) as e:
         Grammar(r"""
             foo = ~b"foo"
             bar = "bar"
         """)
-    assert str(e.value).startswith("BadGrammar:")
+    assert e.value.original_class is BadGrammar
+
+    # The following should parse without errors because they use the same
+    # string types:
     Grammar(r"""
         foo = b"foo"
         bar = b"bar"

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 import sys
 import pytest
 
-from parsimonious.exceptions import UndefinedLabel, ParseError
+from parsimonious.exceptions import UndefinedLabel, ParseError, VisitationError
 from parsimonious.expressions import Literal, Lookahead, Regex, Sequence, TokenMatcher, is_callable
 from parsimonious.grammar import rule_grammar, RuleVisitor, Grammar, TokenGrammar, LazyReference
 from parsimonious.nodes import Node
@@ -524,3 +524,26 @@ def test_binary_grammar():
     """)
     length = 22
     assert g.parse(b"\xff22~" + (b"a" * 22) + b"\xff") is not None
+
+
+def test_inconsistent_string_types_in_grammar():
+    with pytest.raises(VisitationError) as e:
+        Grammar(r"""
+            foo = b"foo"
+            bar = "bar"
+        """)
+    assert str(e.value).startswith("BadGrammar:")
+    with pytest.raises(VisitationError) as e:
+        Grammar(r"""
+            foo = ~b"foo"
+            bar = "bar"
+        """)
+    assert str(e.value).startswith("BadGrammar:")
+    Grammar(r"""
+        foo = b"foo"
+        bar = b"bar"
+    """)
+    Grammar(r"""
+        foo = "foo"
+        bar = "bar"
+    """)

--- a/parsimonious/utils.py
+++ b/parsimonious/utils.py
@@ -12,9 +12,11 @@ class StrAndRepr(object):
 
 def evaluate_string(string):
     """Piggyback on Python's string support so we can have backslash escaping
-    and niceties like \n, \t, etc. string.decode('string_escape') would have
-    been a lower-level possibility.
+    and niceties like \n, \t, etc.
 
+    This also supports:
+    1. b"strings", allowing grammars to parse bytestrings, in addition to str.
+    2. r"strings" to simplify regexes.
     """
     return ast.literal_eval(string)
 


### PR DESCRIPTION
# Changes

## Fix precedence of modified string literals

Fixes #201, wherein the precedence of modified strings like `r"..."` was wrong, causing those strings to be parsed as a reference `r` followed by a string literal. This is technically a breaking change, since grammars like the following are no longer valid:
```
foo = baz"bar"
baz = "baz"
```

However, the fix is fairly straightforward (add some spaces), and this was probably a fairly rare occurrence anyway.

I'm guessing this was not previously caught because modifiers were only useful for `~r"regex nodes"`, where the precedence was correct. However, modified string literals are required for next feature.

## Support for parsing binary files

This turned out to be _much_ easier than I'd anticipated because of Erik’s clever use of `ast.literal_eval` to evaluate string literals.

Once you can define a bytes literal in a grammar, everything "just works" because at base, parsimonious is just calling `.startswith(...)`, `.endswith(...)` and `re.match`, all of which work fine as long as the arguments' types match (`str` xor `bytes`). 

To make this feature easier to use, I added a validation that all string literals (and by extension regexes) must be of the same type.

I added some documentation for the feature, but I'm happy to add to another section if you think it's warranted.

# Testing

All of the changes are tested by unit tests asserting:
* Precedence of modified string literals is correct.
* Grammar strings with bytes literals inside can be parsed into grammars.
* Grammar strings with _both_ bytes and str literals raise an error.