### PR TITLE
Fix star token grammar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -282,6 +282,15 @@ Syntax Reference
 
 ``(things)``            Parentheses are used for grouping, like in every other
                         language.
+
+``thing{n}``            Exactly ``n`` repetitions of ``thing``.
+
+``thing{n,m}``          Between ``n`` and ``m`` repititions (inclusive.)
+
+``thing{,m}``           At most ``m`` repetitions of ``thing``.
+
+``thing{n,}``           At least ``n`` repetitions of ``thing``.
+
 ====================    ========================================================
 
 .. _flags: https://docs.python.org/3/howto/regex.html#compilation
@@ -434,6 +443,8 @@ Version History
 ===============
 
 (Next release)
+  * Add support for range ``{min,max}`` repetition expressions (righthandabacus)
+  * Fix bug in ``*`` and ``+`` for token grammars (lucaswiman)
   * Add support for grammars on bytestrings (lucaswiman)
   .. warning::
 

--- a/parsimonious/exceptions.py
+++ b/parsimonious/exceptions.py
@@ -30,14 +30,17 @@ class ParseError(StrAndRepr, Exception):
         match."""
         # This is a method rather than a property in case we ever wanted to
         # pass in which line endings we want to use.
-        return self.text.count('\n', 0, self.pos) + 1
+        if isinstance(self.text, list):  # TokenGrammar
+            return None
+        else:
+            return self.text.count('\n', 0, self.pos) + 1
 
     def column(self):
         """Return the 1-based column where the expression ceased to match."""
         # We choose 1-based because that's what Python does with SyntaxErrors.
         try:
             return self.pos - self.text.rindex('\n', 0, self.pos)
-        except ValueError:
+        except (ValueError, AttributeError):
             return self.pos + 1
 
 

--- a/parsimonious/expressions.py
+++ b/parsimonious/expressions.py
@@ -422,18 +422,18 @@ class Quantifier(Compound):
 
     def _as_rhs(self):
         if self.min == 0 and self.max == 1:
-            qualifier = u'?'
+            qualifier = '?'
         elif self.min == 0 and self.max == float('inf'):
-            qualifier = u'*'
+            qualifier = '*'
         elif self.min == 1 and self.max == float('inf'):
-            qualifier = u'+'
+            qualifier = '+'
         elif self.max == float('inf'):
-            qualifier = u'{%d,}' % self.min
+            qualifier = '{%d,}' % self.min
         elif self.min == 0:
-            qualifier = u'{,%d}' % self.max
+            qualifier = '{,%d}' % self.max
         else:
-            qualifier = u'{%d,%d}' % (self.min, self.max)
-        return u'%s%s' % (self._unicode_members()[0], qualifier)
+            qualifier = '{%d,%d}' % (self.min, self.max)
+        return '%s%s' % (self._unicode_members()[0], qualifier)
 
 def ZeroOrMore(member, name=''):
     return Quantifier(member, name=name, min=0, max=float('inf'))

--- a/parsimonious/expressions.py
+++ b/parsimonious/expressions.py
@@ -377,9 +377,9 @@ class Lookahead(Compound):
 
     __slots__ = ['negativity']
 
-    def __init__(self, *members, **kwargs):
-        super(Lookahead, self).__init__(*members, **kwargs)
-        self.negativity = bool(kwargs.get('negative'))
+    def __init__(self, member, *, negative=False, **kwargs):
+        super(Lookahead, self).__init__(member, **kwargs)
+        self.negativity = bool(negative)
 
     def _uncached_match(self, text, pos, cache, error):
         node = self.members[0].match_core(text, pos, cache, error)
@@ -399,10 +399,10 @@ class Quantifier(Compound):
 
     __slots__ = ['min', 'max']
 
-    def __init__(self, *members, **kwargs):
-        super(Quantifier, self).__init__(*members, **kwargs)
-        self.min = kwargs.get('min', 0)
-        self.max = kwargs.get('max', float('inf'))
+    def __init__(self, member, *, min=0, max=float('inf'), name='', **kwargs):
+        super(Quantifier, self).__init__(member, name=name, **kwargs)
+        self.min = min
+        self.max = max
 
     def _uncached_match(self, text, pos, cache, error):
         new_pos = pos
@@ -435,11 +435,11 @@ class Quantifier(Compound):
             qualifier = u'{%d,%d}' % (self.min, self.max)
         return u'%s%s' % (self._unicode_members()[0], qualifier)
 
-def ZeroOrMore(*args, **kwargs):
-    return Quantifier(*args, **kwargs)
+def ZeroOrMore(member, name=''):
+    return Quantifier(member, name=name, min=0, max=float('inf'))
 
 def OneOrMore(member, name='', min=1):
-    return Quantifier(member, name=name, min=min)
+    return Quantifier(member, name=name, min=min, max=float('inf'))
 
-def Optional(*args, **kwargs):
-    return Quantifier(*args, **kwargs)
+def Optional(member, name=''):
+    return Quantifier(member, name=name, min=0, max=1)

--- a/parsimonious/expressions.py
+++ b/parsimonious/expressions.py
@@ -375,90 +375,34 @@ class Lookahead(Compound):
     """An expression which consumes nothing, even if its contained expression
     succeeds"""
 
-    # TODO: Merge this and Not for better cache hit ratios and less code.
-    # Downside: pretty-printed grammars might be spelled differently than what
-    # went in. That doesn't bother me.
+    __slots__ = ['negativity']
+
+    def __init__(self, *members, **kwargs):
+        super(Lookahead, self).__init__(*members, **kwargs)
+        self.negativity = bool(kwargs.get('negative'))
 
     def _uncached_match(self, text, pos, cache, error):
         node = self.members[0].match_core(text, pos, cache, error)
-        if node is not None:
+        if (node is None) == self.negativity: # negative lookahead == match only if not found
             return Node(self, text, pos, pos)
 
     def _as_rhs(self):
-        return u'&%s' % self._unicode_members()[0]
+        return u'%s%s' % ('!' if self.negativity else '&', self._unicode_members()[0])
 
-
-class Not(Compound):
-    """An expression that succeeds only if the expression within it doesn't
-
-    In any case, it never consumes any characters; it's a negative lookahead.
-
-    """
-    def _uncached_match(self, text, pos, cache, error):
-        # FWIW, the implementation in Parsing Techniques in Figure 15.29 does
-        # not bother to cache NOTs directly.
-        node = self.members[0].match_core(text, pos, cache, error)
-        if node is None:
-            return Node(self, text, pos, pos)
-
-    def _as_rhs(self):
-        # TODO: Make sure this parenthesizes the member properly if it's an OR
-        # or AND.
-        return u'!%s' % self._unicode_members()[0]
-
+def Not(term):
+    return Lookahead(term, negative=True)
 
 # Quantifiers. None of these is strictly necessary, but they're darn handy.
 
-class Optional(Compound):
-    """An expression that succeeds whether or not the contained one does
+class Quantifier(Compound):
+    """An expression wrapper like the */+/?/{n,m} quantifier in regexes."""
 
-    If the contained expression succeeds, it goes ahead and consumes what it
-    consumes. Otherwise, it consumes nothing.
+    __slots__ = ['min', 'max']
 
-    """
-    def _uncached_match(self, text, pos, cache, error):
-        node = self.members[0].match_core(text, pos, cache, error)
-        return (Node(self, text, pos, pos) if node is None else
-                Node(self, text, pos, node.end, children=[node]))
-
-    def _as_rhs(self):
-        return u'%s?' % self._unicode_members()[0]
-
-
-# TODO: Merge with OneOrMore.
-class ZeroOrMore(Compound):
-    """An expression wrapper like the * quantifier in regexes."""
-
-    def _uncached_match(self, text, pos, cache, error):
-        new_pos = pos
-        children = []
-        while True:
-            node = self.members[0].match_core(text, new_pos, cache, error)
-            if node is None or not (node.end - node.start):
-                # Node was None or 0 length. 0 would otherwise loop infinitely.
-                return Node(self, text, pos, new_pos, children)
-            children.append(node)
-            new_pos += node.end - node.start
-
-    def _as_rhs(self):
-        return u'%s*' % self._unicode_members()[0]
-
-
-class OneOrMore(Compound):
-    """An expression wrapper like the + quantifier in regexes.
-
-    You can also pass in an alternate minimum to make this behave like "2 or
-    more", "3 or more", etc.
-
-    """
-    __slots__ = ['min']
-
-    # TODO: Add max. It should probably succeed if there are more than the max
-    # --just not consume them.
-
-    def __init__(self, member, name='', min=1):
-        super(OneOrMore, self).__init__(member, name=name)
-        self.min = min
+    def __init__(self, *members, **kwargs):
+        super(Quantifier, self).__init__(*members, **kwargs)
+        self.min = kwargs.get('min', 0)
+        self.max = kwargs.get('max', float('inf'))
 
     def _uncached_match(self, text, pos, cache, error):
         new_pos = pos
@@ -466,14 +410,37 @@ class OneOrMore(Compound):
         while True:
             node = self.members[0].match_core(text, new_pos, cache, error)
             if node is None:
-                break
+                break # no more matches
             children.append(node)
             length = node.end - node.start
-            if length == 0:  # Don't loop infinitely.
+            if len(children) >= self.min and length == 0:  # Don't loop infinitely
                 break
             new_pos += length
+            if len(children) == self.max:
+                break # reached max repetition
         if len(children) >= self.min:
             return Node(self, text, pos, new_pos, children)
 
     def _as_rhs(self):
-        return u'%s+' % self._unicode_members()[0]
+        if self.min == 0 and self.max == 1:
+            qualifier = u'?'
+        elif self.min == 0 and self.max == float('inf'):
+            qualifier = u'*'
+        elif self.min == 1 and self.max == float('inf'):
+            qualifier = u'+'
+        elif self.max == float('inf'):
+            qualifier = u'{%d,}' % self.min
+        elif self.min == 0:
+            qualifier = u'{,%d}' % self.max
+        else:
+            qualifier = u'{%d,%d}' % (self.min, self.max)
+        return u'%s%s' % (self._unicode_members()[0], qualifier)
+
+def ZeroOrMore(*args, **kwargs):
+    return Quantifier(*args, **kwargs)
+
+def OneOrMore(member, name='', min=1):
+    return Quantifier(member, name=name, min=min)
+
+def Optional(*args, **kwargs):
+    return Quantifier(*args, **kwargs)

--- a/parsimonious/expressions.py
+++ b/parsimonious/expressions.py
@@ -407,7 +407,8 @@ class Quantifier(Compound):
     def _uncached_match(self, text, pos, cache, error):
         new_pos = pos
         children = []
-        while True:
+        size = len(text)
+        while new_pos < size and len(children) < self.max:
             node = self.members[0].match_core(text, new_pos, cache, error)
             if node is None:
                 break # no more matches
@@ -416,8 +417,6 @@ class Quantifier(Compound):
             if len(children) >= self.min and length == 0:  # Don't loop infinitely
                 break
             new_pos += length
-            if len(children) == self.max:
-                break # reached max repetition
         if len(children) >= self.min:
             return Node(self, text, pos, new_pos, children)
 

--- a/parsimonious/grammar.py
+++ b/parsimonious/grammar.py
@@ -10,7 +10,7 @@ from textwrap import dedent
 
 from parsimonious.exceptions import BadGrammar, UndefinedLabel
 from parsimonious.expressions import (Literal, Regex, Sequence, OneOf,
-    Lookahead, Optional, ZeroOrMore, OneOrMore, Not, TokenMatcher,
+    Lookahead, Quantifier, Optional, ZeroOrMore, OneOrMore, Not, TokenMatcher,
     expression, is_callable)
 from parsimonious.nodes import NodeVisitor
 from parsimonious.utils import evaluate_string
@@ -241,7 +241,7 @@ rule_syntax = (r'''
     atom = reference / literal / regex / parenthesized
     regex = "~" spaceless_literal ~"[ilmsuxa]*"i _
     parenthesized = "(" _ expression ")" _
-    quantifier = ~"[*+?]" _
+    quantifier = ~"[*+?]|\{\d*,\d+\}|\{\d+,\d*\}|\{\d+\}" _
     reference = label !equals
 
     # A subsequent equal sign is the only thing that distinguishes a label
@@ -305,7 +305,17 @@ class RuleVisitor(NodeVisitor):
 
     def visit_quantified(self, node, quantified):
         atom, quantifier = quantified
-        return self.quantifier_classes[quantifier.text](atom)
+        try:
+            return self.quantifier_classes[quantifier.text](atom)
+        except KeyError:
+            # This should pass: assert re.full_match("\{(\d*)(,(\d*))?\}", quantifier)
+            quantifier = quantifier.text[1:-1].split(",")
+            if len(quantifier) == 1:
+                min_match = max_match = int(quantifier[0])
+            else:
+                min_match = int(quantifier[0]) if quantifier[0] else 0
+                max_match = int(quantifier[1]) if quantifier[1] else float('inf')
+            return Quantifier(atom, min=min_match, max=max_match)
 
     def visit_lookahead_term(self, node, lookahead_term):
         ampersand, term, _ = lookahead_term

--- a/parsimonious/grammar.py
+++ b/parsimonious/grammar.py
@@ -241,7 +241,7 @@ rule_syntax = (r'''
     atom = reference / literal / regex / parenthesized
     regex = "~" spaceless_literal ~"[ilmsuxa]*"i _
     parenthesized = "(" _ expression ")" _
-    quantifier = ~"[*+?]|\{\d*,\d+\}|\{\d+,\d*\}|\{\d+\}" _
+    quantifier = ~r"[*+?]|\{\d*,\d+\}|\{\d+,\d*\}|\{\d+\}" _
     reference = label !equals
 
     # A subsequent equal sign is the only thing that distinguishes a label

--- a/parsimonious/tests/test_expressions.py
+++ b/parsimonious/tests/test_expressions.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 
 from parsimonious.exceptions import ParseError, IncompleteParseError
 from parsimonious.expressions import (Literal, Regex, Sequence, OneOf, Not,
-                                      Optional, ZeroOrMore, OneOrMore, Expression)
+                                      Quantifier, Optional, ZeroOrMore, OneOrMore, Expression)
 from parsimonious.grammar import Grammar, rule_grammar
 from parsimonious.nodes import Node
 
@@ -305,7 +305,7 @@ class SlotsTests(TestCase):
         But it does.
 
         """
-        class Smoo(Optional):
+        class Smoo(Quantifier):
             __slots__ = ['smoo']
 
             def __init__(self):

--- a/parsimonious/tests/test_expressions.py
+++ b/parsimonious/tests/test_expressions.py
@@ -24,7 +24,7 @@ class LengthTests(TestCase):
 
         """
         node_length = None if node is None else node.end - node.start
-        self.assertTrue(node_length == length)
+        assert node_length == length
 
     def test_regex(self):
         self.len_eq(Literal('hello').match('ehello', 1), 5)  # simple

--- a/parsimonious/tests/test_expressions.py
+++ b/parsimonious/tests/test_expressions.py
@@ -64,7 +64,10 @@ class LengthTests(TestCase):
         self.len_eq(OneOrMore(Literal('b')).match('b'), 1)  # one
         self.len_eq(OneOrMore(Literal('b')).match('bbb'), 3)  # more
         self.len_eq(OneOrMore(Literal('b'), min=3).match('bbb'), 3)  # with custom min; success
+        self.len_eq(Quantifier(Literal('b'), min=3, max=5).match('bbbb'), 4)  # with custom min and max; success
+        self.len_eq(Quantifier(Literal('b'), min=3, max=5).match('bbbbbb'), 5)  # with custom min and max; success
         self.assertRaises(ParseError, OneOrMore(Literal('b'), min=3).match, 'bb')  # with custom min; failure
+        self.assertRaises(ParseError, Quantifier(Literal('b'), min=3, max=5).match, 'bb')  # with custom min and max; failure
         self.len_eq(OneOrMore(Regex('^')).match('bb'), 0)  # attempt infinite loop
 
 
@@ -266,6 +269,20 @@ class RepresentationTests(TestCase):
         # ZeroOrMore
         self.assertEqual(str(Grammar('foo = "bar" ("baz" "eggs")* "spam"')),
                          u"foo = 'bar' ('baz' 'eggs')* 'spam'")
+
+        # Quantifiers
+        self.assertEqual(str(Grammar('foo = "bar" ("baz" "eggs"){2,4} "spam"')),
+                         "foo = 'bar' ('baz' 'eggs'){2,4} 'spam'")
+        self.assertEqual(str(Grammar('foo = "bar" ("baz" "eggs"){2,} "spam"')),
+                         "foo = 'bar' ('baz' 'eggs'){2,} 'spam'")
+        self.assertEqual(str(Grammar('foo = "bar" ("baz" "eggs"){1,} "spam"')),
+                         "foo = 'bar' ('baz' 'eggs')+ 'spam'")
+        self.assertEqual(str(Grammar('foo = "bar" ("baz" "eggs"){,4} "spam"')),
+                         "foo = 'bar' ('baz' 'eggs'){,4} 'spam'")
+        self.assertEqual(str(Grammar('foo = "bar" ("baz" "eggs"){0,1} "spam"')),
+                         "foo = 'bar' ('baz' 'eggs')? 'spam'")
+        self.assertEqual(str(Grammar('foo = "bar" ("baz" "eggs"){0,} "spam"')),
+                         "foo = 'bar' ('baz' 'eggs')* 'spam'")
 
         # OneOf
         self.assertEqual(str(Grammar('foo = "bar" ("baz" / "eggs") "spam"')),

--- a/parsimonious/tests/test_expressions.py
+++ b/parsimonious/tests/test_expressions.py
@@ -50,6 +50,8 @@ class LengthTests(TestCase):
     def test_optional(self):
         self.len_eq(Sequence(Optional(Literal('a')), Literal('b')).match('b'), 1)  # contained expr fails
         self.len_eq(Sequence(Optional(Literal('a')), Literal('b')).match('ab'), 2)  # contained expr succeeds
+        self.len_eq(Optional(Literal('a')).match('aa'), 1)
+        self.len_eq(Optional(Literal('a')).match('bb'), 0)
 
     def test_zero_or_more(self):
         self.len_eq(ZeroOrMore(Literal('b')).match(''), 0)  # zero

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -3,6 +3,7 @@
 from sys import version_info
 from unittest import TestCase
 
+import pytest
 import sys
 import pytest
 
@@ -483,9 +484,9 @@ class TokenGrammarTests(TestCase):
         grammar = TokenGrammar("""
             foo = "token1" "token2"
             """)
-        self.assertRaises(ParseError,
-                      grammar.parse,
-                      [Token('tokenBOO'), Token('token2')])
+        with pytest.raises(ParseError) as e:
+            grammar.parse([Token('tokenBOO'), Token('token2')])
+        assert "Rule 'foo' didn't match at" in str(e.value)
 
     def test_token_repr(self):
         t = Token(u'💣')

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -491,10 +491,29 @@ class TokenGrammarTests(TestCase):
     def test_token_repr(self):
         t = Token(u'💣')
         self.assertTrue(isinstance(t.__repr__(), str))
-        if sys.version_info < (3, 0):
-            self.assertEqual(u'<Token "💣">'.encode('utf-8'), t.__repr__())
-        else:
-            self.assertEqual(u'<Token "💣">', t.__repr__())
+        self.assertEqual(u'<Token "💣">', t.__repr__())
+
+    def test_token_star_plus_expressions(self):
+        a = Token("a")
+        b = Token("b")
+        grammar = TokenGrammar("""
+            foo = "a"*
+            bar = "a"+
+        """)
+        assert grammar["foo"].parse([]) is not None
+        assert grammar["foo"].parse([a]) is not None
+        assert grammar["foo"].parse([a, a]) is not None
+
+        with pytest.raises(ParseError):
+            grammar["foo"].parse([a, b])
+        with pytest.raises(ParseError):
+            grammar["foo"].parse([b])
+
+        assert grammar["bar"].parse([a]) is not None
+        with pytest.raises(ParseError):
+            grammar["bar"].parse([a, b])
+        with pytest.raises(ParseError):
+            grammar["bar"].parse([b])
 
 
 def test_precedence_of_string_modifiers():
@@ -551,3 +570,25 @@ def test_inconsistent_string_types_in_grammar():
         foo = "foo"
         bar = "bar"
     """)
+
+    def test_token_star_plus_expressions(self):
+        a = Token("a")
+        b = Token("b")
+        grammar = TokenGrammar("""
+            foo = "a"*
+            bar = "a"+
+        """)
+        assert grammar["foo"].parse([]) is not None
+        assert grammar["foo"].parse([a]) is not None
+        assert grammar["foo"].parse([a, a]) is not None
+
+        with pytest.raises(ParseError):
+            grammar["foo"].parse([a, b])
+        with pytest.raises(ParseError):
+            grammar["foo"].parse([b])
+
+        assert grammar["bar"].parse([a]) is not None
+        with pytest.raises(ParseError):
+            grammar["bar"].parse([a, b])
+        with pytest.raises(ParseError):
+            grammar["bar"].parse([b])

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -570,25 +570,3 @@ def test_inconsistent_string_types_in_grammar():
         foo = "foo"
         bar = "bar"
     """)
-
-    def test_token_star_plus_expressions(self):
-        a = Token("a")
-        b = Token("b")
-        grammar = TokenGrammar("""
-            foo = "a"*
-            bar = "a"+
-        """)
-        assert grammar["foo"].parse([]) is not None
-        assert grammar["foo"].parse([a]) is not None
-        assert grammar["foo"].parse([a, a]) is not None
-
-        with pytest.raises(ParseError):
-            grammar["foo"].parse([a, b])
-        with pytest.raises(ParseError):
-            grammar["foo"].parse([b])
-
-        assert grammar["bar"].parse([a]) is not None
-        with pytest.raises(ParseError):
-            grammar["bar"].parse([a, b])
-        with pytest.raises(ParseError):
-            grammar["bar"].parse([b])


### PR DESCRIPTION
@lonnen @erikrose Fixes #173. Fixes #171. Fixes #139. This PR fixes two bugs I've found with token grammars:
* Parsing errors raise a nonsense exception because it's trying to compute the line number for the position, which makes no sense for a list of tokens.
* `*` and `+` just completely do not work due to a bug where they run off the end of the list of tokens leading to an `IndexError`. This works for strings because `.startswith` returns false for an index beyond the size of the string, e.g.:

```python
>>> 'aa'.startswith('a', 2)
False
>>> 'aa'[2]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
IndexError: string index out of range
```

## Changes

I updated the test of parse errors in token grammars so that it asserts the help message in the exception. I fixed the message in `ParseError` so it displays something sensible, which fixed the test.

I added a test of `*` and `+` for token grammars, which failed. I addressed a TODO, combining `OneOrMore`, `ZeroOrMore` and `Optional` into a single base class, also adding the ability to add a maximum number of matches. I then fixed the bug in the implementation, preventing the parser from running off then end of the tokens list.

## Notes

1. I would be interested in adding the max-matches feature to the underlying rules syntax if you are amenable. This would be similar to regex's `a{3,5}` syntax (matches between 3 and 5 "a" characters).  It's a small amount of code, and would be useful in some cases where fields have a maximum length. In any case, IMO it should at least be available as a user extension. I'd be happy to do that in this PR or in another PR.
2. I think the bugginess of `*` and `+`, which are essential to any nontrivial grammar, is suggestive that token grammars have never actually been used by anyone for any practical purpose. I think this may be because they're very limited, since any matching of string literals needs to be done in the lexer. This seems to be common (e.g. Lark also does this), presumably a layover from the lex/yacc days of parsing. However, for most data formats _other_ than programming languages, that's a questionable decision. In my attempts to use token grammars for parsing a document format called x12 (that also motivated this issue), I've found the inability to match string literals in the grammar extremely limiting. That format has configurable delimiters, which seems to require a lexer, but otherwise the format is something that an "ordinary" parsimonious grammar would be great for. I'll make a separate PR with a proposal for making `TokenGrammar` more useful in this regard. 
3. Inheritance can have negative performance impacts, since resolving a method needs to traverse the MRO. I think defining `OneOrMore`, `ZeroOrMore` and `Optional` using `Optional = partial(Repeated, min=0, max=1)` would be more performant at parse time than the current subclassing approach. However, that would prevent users from subclassing them, which might be considered a breaking change. Using `partial` feels simpler to me, but I'm happy to do whatever is most expedient for getting these fixes released.