### PR TITLE
Simplify reference resolution.

### DIFF
--- a/parsimonious/expressions.py
+++ b/parsimonious/expressions.py
@@ -119,6 +119,10 @@ class Expression(StrAndRepr):
     def __ne__(self, other):
         return not (self == other)
 
+    def resolve_refs(self, rule_map):
+        # Nothing to do on the base expression.
+        return self
+
     def parse(self, text, pos=0):
         """Return a parse tree of ``text``.
 
@@ -312,6 +316,10 @@ class Compound(Expression):
         """``members`` is a sequence of expressions."""
         super(Compound, self).__init__(kwargs.get('name', ''))
         self.members = members
+
+    def resolve_refs(self, rule_map):
+        self.members = tuple(m.resolve_refs(rule_map) for m in self.members)
+        return self
 
     def __hash__(self):
         # Note we leave members out of the hash computation, since compounds can get added to

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -326,6 +326,24 @@ class GrammarTests(TestCase):
             main = number
             """)
 
+    def test_circular_toplevel_reference(self):
+        with pytest.raises(VisitationError):
+            Grammar("""
+                foo = bar
+                bar = foo
+            """)
+        with pytest.raises(VisitationError):
+            Grammar("""
+                foo = foo
+                bar = foo
+            """)
+        with pytest.raises(VisitationError):
+            Grammar("""
+                foo = bar
+                bar = baz
+                baz = foo
+            """)
+
     def test_right_recursive(self):
         """Right-recursive refs should resolve."""
         grammar = Grammar("""


### PR DESCRIPTION
Followup to #141, simplifying lazy reference resolution. The key insight here is that either:
1. Every lazy reference can be resolved to an `Expression` just from the original grammar definition, or
2. There is a circular reference chain of lazy refs in the original definition.

What was happening prior to #141, is that lazy references were only being resolved one level deep, which (depending on ordering) stuck more lazy references in child nodes, which then need to be fixed again. So e.g. in Erik's test case reproducing the issue, it contains the lines:
```
            _ = meaninglessness*
            meaninglessness = whitespace
```
Since the are resolved in order, the first rule resolves to `_ = <LazyReference to whitespace>*`, _then_ the second rule resolves correctly, but it's already too late.

The fix in #141 was to basically check the entire grammar every time a new lazy reference was resolved, which works, but is inefficient and can be simplified. This PR just follows each lazy reference down the chain of references whenever we need to resolve it. 

### Note

The goal in invalidating grammars with circular reference chains isn't to invalidate all circular references (though that's maybe a good idea if it's possible), just to those whose lazy references cannot be resolved. So e.g. the following grammar _is_ circular, but its lazy references can all be resolved down to concrete expressions (Sequences whose members reference each other):
```
foo = bar ""
bar = "" foo
```

However, the lazy references can never be resolved in a grammar like the following:
```
foo = bar
bar = foo
```

There it's lazy refs all the way down.

<hr>

cc @righthandabacus 