### PR TITLE
Test and exception improvements

### DIFF
--- a/parsimonious/nodes.py
+++ b/parsimonious/nodes.py
@@ -222,7 +222,7 @@ class NodeVisitor(object, metaclass=RuleDecoratorMeta):
             # Catch any exception, and tack on a parse tree so it's easier to
             # see where it went wrong.
             exc_class = type(exc)
-            raise VisitationError(exc, exc_class, node)
+            raise VisitationError(exc, exc_class, node) from exc
 
     def generic_visit(self, node, visited_children):
         """Default visitor method

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,6 @@ python =
 
 [testenv]
 usedevelop = True
-commands = py.test
+commands = py.test --tb=native
 deps =
   pytest

--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,6 @@ python =
 
 [testenv]
 usedevelop = True
-commands = py.test --tb=native
+commands = py.test --tb=native {posargs:parsimonious}
 deps =
   pytest


### PR DESCRIPTION
A few small improvements:
1. Use `raise ... from ...` when raising a visitation error. This slightly improves the traceback.
2. Update tox/pytest setup:
  * Use `--tb=native` to make failures more concise.
  * Add an option to tox to run a particular test (e.g. `tox parsimonious/tests/test_grammar.py::sometest`)