### PR TITLE
Grammar extensions

### DIFF
--- a/parsimonious/expressions.py
+++ b/parsimonious/expressions.py
@@ -122,6 +122,9 @@ class Expression(StrAndRepr):
         # Nothing to do on the base expression.
         return self
 
+    def resolve_inherited_references(self, rule_map):
+        return self
+
     def parse(self, text, pos=0):
         """Return a parse tree of ``text``.
 
@@ -319,6 +322,10 @@ class Compound(Expression):
 
     def resolve_refs(self, rule_map):
         self.members = tuple(m.resolve_refs(rule_map) for m in self.members)
+        return self
+
+    def resolve_inherited_references(self, rule_map):
+        self.members = tuple(m.resolve_inherited_references(rule_map) for m in self.members)
         return self
 
     def __hash__(self):

--- a/parsimonious/tests/examples/grammar_syntax_extension.py
+++ b/parsimonious/tests/examples/grammar_syntax_extension.py
@@ -1,0 +1,78 @@
+"""
+This example extends parsimonious's grammar syntax for a different approach to token grammars:
+* CAPITALIZED references are refer to ``token.type`` names. They do not need to be explicitly
+  named elsewhere in the grammar.
+* lowercase references are refer to other rules.
+* A token's attributes can match rules, e.g. requiring that an attribute be a date in a particular
+  format. This uses a syntax similar to Xpath's ``node[@attr='value']`` syntax.
+"""
+
+from typing import Dict
+
+from parsimonious.grammar import Grammar
+from parsimonious.expressions import Expression
+from parsimonious.nodes import Node
+
+
+class TokenRef(Expression):
+    def __init__(self, ref, name=""):
+        super().__init__(name=name)
+        self.ref = ref
+
+    def _uncached_match(self, token_list, pos, cache, error):
+        if self.ref == getattr(token_list[pos], "type", None):
+            return Node(self, token_list, pos, pos + 1, children=[])
+
+
+class AttrsPredicateExpression(Expression):
+    """
+    A predicate expression that matches a node with a given set of attributes.
+    """
+
+    def __init__(self, token_type, attrs: Dict[str, str]):
+        self.attrs = attrs
+        self.token_type = token_type
+
+    def __repr__(self) -> str:
+        return f"AttrsPredicateExpression({self.token_type}[{self.attrs}])" % self.attrs
+
+    def _uncached_match(self, token_list, pos, cache, error):
+
+        tok_match = self.token_type.match_core(token_list, pos, cache, error)
+        if tok_match:
+            tok = token_list[pos]
+            for k, v in self.attrs.items():
+                attr = getattr(tok, k, None)
+                if not isinstance(attr, str) or not v.parse(attr):
+                    return None
+            # TODO: should children have each of the attr matches?
+            return Node(self, token_list, pos, pos+1, children=[tok_match])
+
+
+class AttrsTokenGrammar(Grammar):
+    rule_grammar = Grammar.rule_grammar.extend(r"""
+        # TODO: Support lexer natively?
+        term = attrs_predicate_expression / ^term
+
+        # Token names are required to be all-caps alphanumeric, with underscores.
+        reference = token_reference / ^reference
+        token_reference = ~r"[A-Z_][A-Z0-9_]*"
+
+        attrs_predicate_expression = token_reference "[" _ attr_expressions "]" _
+        attr_expressions = ("@" label "=" _ expression _)+
+    """)
+
+    class visitor_cls(Grammar.visitor_cls):
+        def visit_token_reference(self, node, children) -> str:
+            return TokenRef(node.text)
+
+        def visit_attrs_predicate_expression(self, node, children):
+            label, _, lbrac,  attr_expressions, rbrac, _ = children
+            return AttrsPredicateExpression(label, attr_expressions)
+
+        def visit_attr_expressions(self, node, children) -> Dict[str, Expression]:
+            predicates = {}
+            for at, label, equals, _, expression, _ in children:
+                assert isinstance(label, str)
+                predicates[label] = expression
+            return predicates

--- a/parsimonious/tests/test_examples.py
+++ b/parsimonious/tests/test_examples.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+
+import pytest
+
+from parsimonious.exceptions import ParseError
+from parsimonious.tests.examples.grammar_syntax_extension import AttrsTokenGrammar
+
+
+def noparse(grammar, text):
+    with pytest.raises(ParseError):
+        grammar.parse(text)
+
+
+def test_extended_grammar():
+    g = AttrsTokenGrammar(r"""
+       a = B[@foo=("bar" / "baz") @baz=~"baz"+]
+    """)
+
+    assert g.parse([SimpleNamespace(type="B", foo="bar", baz="bazbaz")])
+    assert g.parse([SimpleNamespace(type="B", foo="baz", baz="bazbaz")])
+    noparse(g, [SimpleNamespace(type="C", foo="bar", baz="baz")])
+    noparse(g, [SimpleNamespace(type="C", foo="bar", baz="baz")])

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -168,7 +168,7 @@ class GrammarTests(TestCase):
 
         That the correct ``Expression`` tree is built is already tested in
         ``RuleGrammarTests``. This tests only that the ``Grammar`` base class's
-        ``_expressions_from_rules`` works.
+        ``expressions_from_rules`` works.
 
         """
         greeting_grammar = Grammar('greeting = "hi" / "howdy"')

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -621,7 +621,6 @@ def test_binary_grammar():
         body = ~b"[^\xFF]*"
         terminator = b"\xFF"
     """)
-    length = 22
     assert g.parse(b"\xff22~" + (b"a" * 22) + b"\xff") is not None
 
 
@@ -649,3 +648,37 @@ def test_inconsistent_string_types_in_grammar():
         foo = "foo"
         bar = "bar"
     """)
+
+
+def test_grammar_extend_method():
+    g = Grammar(r"""
+        a = (b / c)+
+        b = "b"
+        c = "c"
+    """)
+    g2 = g.extend(r"""
+        b = ^b / "B"
+        c = ^c / "C"
+    """)
+    assert g.parse("bc")
+    assert g2.parse("bBcC")
+    with pytest.raises(ParseError):
+        g.parse("bBcC")
+
+
+def test_grammar_extend_dsl():
+    g = Grammar(r"""
+        a = (b / c)+
+        b = "b"
+        c = "c"
+    """)
+    g2 = Grammar(fr"""
+        {g.rule_definition[0]}
+        ======================
+        b = ^b / "B"
+        c = ^c / "C"
+    """)
+    assert g.parse("bc")
+    assert g2.parse("bBcC")
+    with pytest.raises(ParseError):
+        g.parse("bBcC")


### PR DESCRIPTION
@erikrose @lonnen This PR proposes a method of extending grammars, including Parsimonious' own rule syntax. Implements #30. 

# Changes

## Syntax for referencing/overriding previously-defined rules.

Erik suggested a syntax like this in #30. It seems reasonable, if a little terse. Very open to suggestions here.

The key point here is that to truly extend functionality of other grammars, references cannot be resolved until _after_ ^super expressions have been resolved. This allows e.g. defining a new kind of `expression`, and having it included anywhere `expression` was used in the original grammar.

**Example:**

```
default = foo*
foo = "bar"
foo = ^foo / "baz"
```
This is equivalent to the following grammar:
```
default = foo*
foo = "bar" / "baz"
```

## Syntax for dividing up rule sections

Two or more `=` or `-` characters makes a new kind of comment. It has no semantic content, though it could be used for refining the inheritance semantics, e.g. around  `**more_rules` custom rules.
```
default = foo*
foo = "bar"
==============
foo = ^foo / "baz"
```

## `Grammar.extend` instance method

Takes the same arguments as the `Grammar` constructor, but instead extends the existing grammar by concatenating the original grammar definition and the new one. To achieve this, the original arguments passed to the constructor are retained. 

## Class variables on `Grammar` to define how a grammar is parsed and visited

Each `Grammar` subclass defines a grammar that parses rules, and a visitor class that visits them.

This allows extensions to parsimonious's syntax without needing to reach consensus on what those extensions should be. Individual users can update the syntax to make a DSL useful for their own purposes.

I included an example of a different approach to token grammars that is useful for a particular problem I'm trying to solve. Here, `CAPITAL_REFERENCES` refer to token types, while lowercase references refer to rules. Attributes of tokens can themselves be matched or parsed with a language similar to xpath.

# Limitations

1. This exposes some parts of the internals as "public" parts of the API, which may be a problem if we need to change those internals. However, this is extremely useful functionality, and would allow making and using proposed syntax changes before or instead of altering the grammar definition DSL. Still, it may make sense to resolve https://github.com/erikrose/parsimonious/issues/199 before shipping this functionality.
2. The `**more_rules` construct is a bit wonky or buggy. Consider the following:
```python
g = Grammar("...", custom_expr=MyCoolCustomExpression())
g2 = g.extend("""
    custom_expr = ^custom_expr / something_else
""")
```

Here the extension doesn't do anything since the extra "custom" overrides the extension. I think there are solutions to this, but they're a bit finicky to implement, so I figured I'd put this up for discussion before continuing.

That said, it doesn't break any existing use of the `**more_rules` feature which is a bit of an advanced/experimental feature anyway.

# Still TODO
- [ ] Add docs for these features
- [ ] Possibly resolve the issue with using `**more_rules`, or at least document the limitation.