### PR TITLE
Infinite recursion left associative

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -443,6 +443,7 @@ Version History
 ===============
 
 (Next release)
+  * Improve error message in left-recursive rules. (lucaswiman)
   * Add support for range ``{min,max}`` repetition expressions (righthandabacus)
   * Fix bug in ``*`` and ``+`` for token grammars (lucaswiman)
   * Add support for grammars on bytestrings (lucaswiman)

--- a/parsimonious/exceptions.py
+++ b/parsimonious/exceptions.py
@@ -1,3 +1,4 @@
+from textwrap import dedent
 
 from parsimonious.utils import StrAndRepr
 
@@ -42,6 +43,20 @@ class ParseError(StrAndRepr, Exception):
             return self.pos - self.text.rindex('\n', 0, self.pos)
         except (ValueError, AttributeError):
             return self.pos + 1
+
+
+class LeftRecursionError(ParseError):
+    def __str__(self):
+        rule_name = self.expr.name if self.expr.name else str(self.expr)
+        window = self.text[self.pos:self.pos + 20]
+        return dedent(f"""
+            Left recursion in rule {rule_name!r} at {window!r} (line {self.line()}, column {self.column()}).
+
+            Parsimonious is a packrat parser, so it can't handle left recursion.
+            See https://en.wikipedia.org/wiki/Parsing_expression_grammar#Indirect_left_recursion
+            for how to rewrite your grammar into a rule that does not use left-recursion.
+            """
+        ).strip()
 
 
 class IncompleteParseError(ParseError):

--- a/parsimonious/expressions.py
+++ b/parsimonious/expressions.py
@@ -10,7 +10,7 @@ from collections import defaultdict
 from inspect import getfullargspec, isfunction, ismethod, ismethoddescriptor
 import regex as re
 
-from parsimonious.exceptions import ParseError, IncompleteParseError
+from parsimonious.exceptions import ParseError, IncompleteParseError, LeftRecursionError
 from parsimonious.nodes import Node, RegexNode
 from parsimonious.utils import StrAndRepr
 
@@ -94,6 +94,9 @@ def expression(callable, rule_name, grammar):
             return '{custom function "%s"}' % callable.__name__
 
     return AdHocExpression(name=rule_name)
+
+
+IN_PROGRESS = object()
 
 
 class Expression(StrAndRepr):
@@ -186,10 +189,10 @@ class Expression(StrAndRepr):
             node = expr_cache[pos]
         else:
             # TODO: Set default value to prevent infinite recursion in left-recursive rules.
-            node = expr_cache[pos] = self._uncached_match(text,
-                                                          pos,
-                                                          cache,
-                                                          error)
+            expr_cache[pos] = IN_PROGRESS  # Mark as in progress
+            node = expr_cache[pos] = self._uncached_match(text, pos, cache, error)
+        if node is IN_PROGRESS:
+            raise LeftRecursionError(text, pos=-1, expr=self)
 
         # Record progress for error reporting:
         if node is None and pos >= error.pos and (

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -663,4 +663,5 @@ def test_left_associative():
     """
 
     grammar = Grammar(language_grammar)
-    grammar.parse('1 + 2')
+    assert grammar["operator_expression"].parse("1+2") is not None
+    grammar.parse("1+2")

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -649,3 +649,18 @@ def test_inconsistent_string_types_in_grammar():
         foo = "foo"
         bar = "bar"
     """)
+
+
+def test_left_associative():
+    # Regression test for https://github.com/erikrose/parsimonious/issues/209
+    language_grammar = r"""
+    expression = operator_expression / non_operator_expression
+    non_operator_expression = number_expression
+
+    operator_expression = expression "+" non_operator_expression
+
+    number_expression = ~"[0-9]+"
+    """
+
+    grammar = Grammar(language_grammar)
+    grammar.parse('1 + 2')

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -4,9 +4,8 @@ from sys import version_info
 from unittest import TestCase
 
 import pytest
-import sys
 
-from parsimonious.exceptions import BadGrammar, UndefinedLabel, ParseError, VisitationError
+from parsimonious.exceptions import BadGrammar, LeftRecursionError, ParseError, UndefinedLabel, VisitationError
 from parsimonious.expressions import Literal, Lookahead, Regex, Sequence, TokenMatcher, is_callable
 from parsimonious.grammar import rule_grammar, RuleVisitor, Grammar, TokenGrammar, LazyReference
 from parsimonious.nodes import Node
@@ -663,5 +662,6 @@ def test_left_associative():
     """
 
     grammar = Grammar(language_grammar)
-    assert grammar["operator_expression"].parse("1+2") is not None
-    grammar.parse("1+2")
+    with pytest.raises(LeftRecursionError) as e:
+        grammar["operator_expression"].parse("1+2")
+    assert "Parsimonious is a packrat parser, so it can't handle left recursion." in str(e.value)


### PR DESCRIPTION
cc @joranmulderij Fixes #209, though not in a particularly satisfying way.

There was a TODO about adding a default value to prevent infinite recursion in `match_core`. While it's a good case to address, I don't think it can be easily "fixed" with a default value. It's fairly fundamental to using a packrat parser in PEGs: left recursion does not work. (See [Wikipedia](https://en.wikipedia.org/wiki/Parsing_expression_grammar#Indirect_left_recursion) linked from [this SO thread](https://stackoverflow.com/questions/24174714/how-do-you-build-a-left-associative-operator-tree-using-peg-js).) To fix this, we would need to switch to another, slower algorithm, or detect left recursion and use the slower algorithm in those cases. 

## Approach that does not work

The obvious thing to do is to temporarily set the match to `None` while evaluating an expr. However, in the example from the ticket, you end up with an imcomplete parse error in `1+2`, where `number_expression` matches at position 0 (the second branch in the first rule), which is not correct. 

## Better error message

I opted to detect the left-recursion case and provide a more helpful error message, linking to Wikipedia's discussion about translating left-recursive rules into indirectly left recursive rules. At some point, we may want to link to parsimonious-specific documentation, but I think this PR is still a directional improvement over the previous behavior.

## Testing

I added and slightly altered the example from #209 as a test case, and verified that it fails. It passes after the last commit on this branch.