### PR TITLE
fixed recursion errors of `Expressions.__eq__`

### DIFF
--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -7,7 +7,7 @@ import pytest
 
 from parsimonious.exceptions import BadGrammar, LeftRecursionError, ParseError, UndefinedLabel, VisitationError
 from parsimonious.expressions import Literal, Lookahead, Regex, Sequence, TokenMatcher, is_callable
-from parsimonious.grammar import rule_grammar, RuleVisitor, Grammar, TokenGrammar, LazyReference
+from parsimonious.grammar import rule_grammar, rule_syntax, RuleVisitor, Grammar, TokenGrammar, LazyReference
 from parsimonious.nodes import Node
 from parsimonious.utils import Token
 
@@ -540,6 +540,12 @@ class GrammarTests(TestCase):
             for example in examples:
                 with pytest.raises(ParseError):
                     grammar[rule].parse(example)
+
+    def test_equal(self):
+        self.assertEqual(Grammar(rule_syntax), Grammar(rule_syntax))
+        self.assertNotEqual(Grammar('expr = ~"[a-z]{1,3}"'), Grammar('expr = ~"[a-z]{2,3}"'))
+        self.assertNotEqual(Grammar('expr = ~"[a-z]{1,3}"'), Grammar('expr = ~"[a-z]{1,4}"'))
+        self.assertNotEqual(Grammar('expr = &"a"'), Grammar('expr = !"a"'))
 
 
 class TokenGrammarTests(TestCase):

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -542,6 +542,13 @@ class GrammarTests(TestCase):
                     grammar[rule].parse(example)
 
     def test_equal(self):
+        grammar_def = (r"""
+            x = y / z / ""
+            y = "y" x
+            z = "z" x
+        """)
+        assert Grammar(grammar_def) == Grammar(grammar_def)
+
         self.assertEqual(Grammar(rule_syntax), Grammar(rule_syntax))
         self.assertNotEqual(Grammar('expr = ~"[a-z]{1,3}"'), Grammar('expr = ~"[a-z]{2,3}"'))
         self.assertNotEqual(Grammar('expr = ~"[a-z]{1,3}"'), Grammar('expr = ~"[a-z]{1,4}"'))


### PR DESCRIPTION
1. The equality of two `Compound`s relies on checking the equality of the corresponding members, and when there is a loop in the membership relations (e.g. A = B, B = (A)) the function will cause a `RecursionError`.
2. `Quantifier` and `Lookahead` lack a `__eq__` which should check the equality of their attributes.