### PR TITLE
Initialize NodeVisitor with default grammar

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -145,10 +145,10 @@ And call it like that:
 
     """
 
-    tree = grammar.parse(data)
+    ini_visitor = IniVisitor(grammar)
 
-    iv = IniVisitor()
-    output = iv.visit(tree)
+    output = ini_visitor.parse(data)
+
     print(output)
 
 This would yield

--- a/parsimonious/nodes.py
+++ b/parsimonious/nodes.py
@@ -188,6 +188,9 @@ class NodeVisitor(object, metaclass=RuleDecoratorMeta):
     #: wrapped in a VisitationError when they arise.
     unwrapped_exceptions = ()
 
+    def __init__(self, grammar=None):
+        self.grammar = grammar
+
     # TODO: If we need to optimize this, we can go back to putting subclasses
     # in charge of visiting children; they know when not to bother. Or we can
     # mark nodes as not descent-worthy in the grammar.


### PR DESCRIPTION
Proposal to allow NodeVisitor to be initialized using a default grammar object.
Old behaviour still works.

- added `__init__` to `NodeVisitor` which accepts a default grammar
- updated README example to use the default grammar initialization method, although perhaps the example needs to show both methods now?

For your consideration / comment. Not sure if I should have raised an issue to discuss first?
Many thanks to you and other contributors for great package :)