### PR TITLE
Add named groups

### DIFF
--- a/parsimonious/grammar.py
+++ b/parsimonious/grammar.py
@@ -238,12 +238,13 @@ rule_syntax = (r'''
     lookahead_term = "&" term _
     term = not_term / lookahead_term / quantified / atom
     quantified = atom quantifier
-    atom = reference / literal / regex / parenthesized
+    atom = reference / literal / regex / parenthesized / named_parenthesized
     regex = "~" spaceless_literal ~"[ilmsuxa]*"i _
     parenthesized = "(" _ expression ")" _
+    named_parenthesized = "(?P<" label ">" _ expression ")" _
     quantifier = ~r"[*+?]|\{\d*,\d+\}|\{\d+,\d*\}|\{\d+\}" _
     reference = label !equals
-
+    
     # A subsequent equal sign is the only thing that distinguishes a label
     # (which begins a new rule) from a reference (which is just a pointer to a
     # rule defined somewhere else):
@@ -324,6 +325,12 @@ class RuleVisitor(NodeVisitor):
 
         """
         left_paren, _, expression, right_paren, _ = parenthesized
+        return expression
+
+    def visit_named_parenthesized(self, node, parenthesized_named):
+        """Set the name of the expression to the given name"""
+        left_paren, label, right_angle, _, expression, right_paren, _ = parenthesized_named
+        expression.name = label
         return expression
 
     def visit_quantifier(self, node, quantifier):

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -275,6 +275,23 @@ class GrammarTests(TestCase):
             <Node matching " ">
             <Node matching "bang">""")
 
+    def test_named_parens(self):
+        grammar = Grammar(r'''sequence = "chitty" (?P<bang_container> " " "bang")+''')
+        # Make sure it's not as if the parens aren't there:
+        self.assertRaises(ParseError, grammar.parse, 'chitty bangbang')
+
+        s = 'chitty bang bang'
+        self.assertEqual(str(grammar.parse(s)),
+            """<Node called "sequence" matching "chitty bang bang">
+    <Node matching "chitty">
+    <Node matching " bang bang">
+        <Node called "bang_container" matching " bang">
+            <Node matching " ">
+            <Node matching "bang">
+        <Node called "bang_container" matching " bang">
+            <Node matching " ">
+            <Node matching "bang">""")
+
     def test_resolve_refs_order(self):
         """Smoke-test a circumstance where lazy references don't get resolved."""
         grammar = Grammar("""


### PR DESCRIPTION
These have the same syntax as named groups in [re](https://docs.python.org/3/library/re.html).

For example:
```python
from parsimonious import Grammar

grammar = Grammar("""
    function = "def" ~"\s+" (?P<func_name> ~"[a-zA-z_]+") "(" (?P<parameter> ~"[a-zA-Z_]+" "," ~"\s*")* "):"
""")

text = "def func(a, b,):"

print(grammar.parse(text))
```
Outputs:
```
<Node called "function" matching "def func(a, b,):">
    <Node matching "def">
    <RegexNode matching " ">
    <RegexNode called "func_name" matching "func">
    <Node matching "(">
    <Node matching "a, b,">
        <Node called "parameter" matching "a, ">
            <RegexNode matching "a">
            <Node matching ",">
            <RegexNode matching " ">
        <Node called "parameter" matching "b,">
            <RegexNode matching "b">
            <Node matching ",">
            <RegexNode matching "">
    <Node matching "):">
```