### PR TITLE
Update expressions.py

### DIFF
--- a/parsimonious/expressions.py
+++ b/parsimonious/expressions.py
@@ -7,7 +7,7 @@ These do the parsing.
 # anything--for speed. And kill all the dots.
 
 from collections import defaultdict
-from inspect import getfullargspec, isfunction, ismethod, ismethoddescriptor
+from inspect import getargs, isfunction, ismethod, ismethoddescriptor
 try:
     import regex as re
 except ImportError:
@@ -67,7 +67,7 @@ def expression(callable, rule_name, grammar):
     if ismethoddescriptor(callable) and hasattr(callable, '__func__'):
         callable = callable.__func__
 
-    num_args = len(getfullargspec(callable).args)
+    num_args = len(getargs(callable).args)
     if ismethod(callable):
         # do not count the first argument (typically 'self') for methods
         num_args -= 1


### PR DESCRIPTION
in latests python and pip version of 03.07.2024 I discovered this issue
 File "..../lib/python3.12/site-packages/parsimonious/expressions.py", line 9, in <module>
    from inspect import getargspec
ImportError: cannot import name 'getargspec' from 'inspect' (..../lib/python3.12/inspect.py). Did you mean: 'getargs'? 
Replicated the error on both linux and windows environments. not sure if what I did fixed the problem, but for me it did the job