### PR TITLE
Fix multiple terms as part of `/` expressions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -445,7 +445,7 @@ Niceties
 Version History
 ===============
 (Next release)
-  * ...
+  * Fix bug #238: correctly handle `/` expressions with multiple terms in a row. (lucaswiman)
 
 0.10.0
   * Fix infinite recursion in __eq__ in some cases. (FelisNivalis)

--- a/parsimonious/tests/test_grammar.py
+++ b/parsimonious/tests/test_grammar.py
@@ -504,6 +504,29 @@ class GrammarTests(TestCase):
             list(grammar.keys()),
             ['r%s' % i for i in range(100)])
 
+    def test_sequence_choice_bug(self):
+        """
+        Regression test for https://github.com/erikrose/parsimonious/issues/238
+        """
+        grammar = Grammar(r'''
+            value = "[" "]" / "5"
+        ''')
+        self.assertTrue(grammar.parse('[]') is not None)
+        self.assertTrue(grammar.parse('5') is not None)
+        grammar2 = Grammar(r'''
+            value = "5" / "[" "]"
+        ''')
+        self.assertTrue(grammar2.parse('[]') is not None)
+        self.assertTrue(grammar2.parse('5') is not None)
+        grammar3 = Grammar(r'''
+            value = "4" / "[" "]" / "(" ")" / "{" "}" / "5"
+        ''')
+        self.assertTrue(grammar3.parse('[]') is not None)
+        self.assertTrue(grammar3.parse('5') is not None)
+        self.assertTrue(grammar3.parse('()') is not None)
+        self.assertTrue(grammar3.parse('{}') is not None)
+        self.assertTrue(grammar3.parse('4') is not None)
+
     def test_repetitions(self):
         grammar = Grammar(r'''
             left_missing = "a"{,5}


### PR DESCRIPTION
Fixes #238.

## Testing

Added a test case reproducing the bug and a related bug (multiple terms on the right of the `/`). I verified they fail, but pass after the commit fixing them.