### PR TITLE
feat: Node.__hash__

### DIFF
--- a/parsimonious/nodes.py
+++ b/parsimonious/nodes.py
@@ -99,6 +99,12 @@ class Node(object):
                 self.end == other.end and
                 self.children == other.children)
 
+    def __hash__(self) -> int:
+        """A unique hash key for this specific Node instance."""
+        return hash(
+            (self.expr, self.full_text, self.start, self.end, self.children)
+        )
+
     def __ne__(self, other):
         return not self == other
 


### PR DESCRIPTION
I was trying to use a Node object as a component of a cache key in https://github.com/ethereum/eth-abi/ but found that Node instances are not hashable

Based on the class docstring, and the docstring for __repr__, it seems that these instances are both immutable and deterministic, making them suitable for hashing and this change should not cause any issues. Hopefully you agree, because while I can use the repr in my cache key instead, it is not the solution I was hoping for! 😅